### PR TITLE
disallow bots from accessing the subscription page

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /submit-subscription/


### PR DESCRIPTION
Bots doing GET requests to the subscription page sometimes results
in other server errors. Disallow robots from accessing the page. We could
start with this content for the robots.txt and allow/disallow specific urls
as and when required.