### PR TITLE
Update the server public key check to account for ssh-keygen changes

### DIFF
--- a/lae_automation/initialize.py
+++ b/lae_automation/initialize.py
@@ -349,7 +349,7 @@ def get_and_store_pubkeyfp_from_keyscan(targetIP, stdout):
     if sp.wait() != 0:
         raise subprocess.CalledProcessError
 
-    return _get_entry_from_keyscan(pubkey_filename)
+    return _get_entry_from_keyscan(pubkey_filepath)
 
 
 def _get_entry_from_keyscan(keyscan_filepath):

--- a/lae_automation/initialize.py
+++ b/lae_automation/initialize.py
@@ -201,6 +201,9 @@ def verify_and_store_serverssh_pubkey(ec2accesskeyid, ec2secretkey, endpoint_uri
 
         def _verifyfp_and_write_pubkey( (fingerprint_from_keyscan, hashed_pubkey) ):
             if fingerprint_from_AWS != fingerprint_from_keyscan:
+                print >>stderr, "Fingerprint from AWS:", fingerprint_from_AWS
+                print >>stderr, "Fingerprint from keyscan:", fingerprint_from_keyscan
+
                 raise PublicKeyMismatch()
             print >>stderr, "The ssh public key on the server has fingerprint: %s" % (fingerprint_from_keyscan,)
             known_hosts_filepath = FilePath(os.path.expanduser('~')).child('.ssh').child('known_hosts')

--- a/lae_automation/initialize.py
+++ b/lae_automation/initialize.py
@@ -349,7 +349,15 @@ def get_and_store_pubkeyfp_from_keyscan(targetIP, stdout):
     if sp.wait() != 0:
         raise subprocess.CalledProcessError
 
-    known_hosts = KnownHostsFile.fromPath(pubkey_filepath)
+    return _get_entry_from_keyscan(pubkey_filename)
+
+
+def _get_entry_from_keyscan(keyscan_filepath):
+    """
+    Read a single-entry known_hosts file and return the fingerprint of
+    the public key of the entry and the serialized entry.
+    """
+    known_hosts = KnownHostsFile.fromPath(keyscan_filepath)
     entries = list(known_hosts.iterentries())
     if len(entries) == 0:
         return None

--- a/lae_automation/server.py
+++ b/lae_automation/server.py
@@ -373,8 +373,9 @@ postfix	postfix/main_mailer_type select	No configuration"""
     print >>stdout, "Installing dependencies..."
     package_list = TAHOE_LAFS_PACKAGE_DEPENDENCIES + EXTRA_INFRASTRUCTURE_PACKAGE_DEPENDENCIES
     apt_install_dependencies(stdout, package_list)
-    # From:  https://stripe.com/docs/libraries
-    sudo('pip install --index-url https://code.stripe.com --upgrade stripe')
+
+    sudo('pip install --upgrade stripe pem')
+
     write(postfixdebconfstring, '/home/ubuntu/postfixdebconfs.txt')
     sudo('debconf-set-selections /home/ubuntu/postfixdebconfs.txt')
     sudo_apt_get('install -y postfix')

--- a/lae_automation/server.py
+++ b/lae_automation/server.py
@@ -160,7 +160,7 @@ TAHOE_LAFS_PACKAGE_DEPENDENCIES = [
 EXTRA_INFRASTRUCTURE_PACKAGE_DEPENDENCIES = [
     'python-jinja2',
     'fabric',
-    'python-twisted-mail',
+    'python-twisted',
     'python-unidecode',
     'python-tz',
     'python-docutils',

--- a/lae_automation/test/test_initialize.py
+++ b/lae_automation/test/test_initialize.py
@@ -3,11 +3,18 @@ import sys
 from twisted.trial.unittest import TestCase
 from twisted.internet import defer
 from twisted.python.failure import Failure
+from twisted.python.filepath import FilePath
+
+from twisted.conch.ssh.keys import Key
+from twisted.conch.client.knownhosts import KnownHostsFile
 
 import mock
 
 import lae_automation.initialize
-from lae_automation.initialize import verify_and_store_serverssh_pubkey, PublicKeyMismatch
+from lae_automation.initialize import (
+    verify_and_store_serverssh_pubkey, PublicKeyMismatch,
+    _get_entry_from_keyscan,
+)
 
 
 ACTIVATIONKEY= 'MOCKACTIVATONKEY'
@@ -43,8 +50,52 @@ class InitializationTests (TestCase):
 
 
 class KeyscanTests(TestCase):
+    """
+    Tests for ``_get_entry_from_keyscan``.
+    """
+    # Dummy key, randomly generated using `ssh-keygen -t rsa -b 1024`
+    # on Ubuntu 16.10.
+    RSA_KEY = Key.fromString("""\
+-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQDPO2Rzfbky7sh1gbmN4+GIRkg+fM6dZEhlJsQqjbBsH9i2tuOc
+kEgkfCpxayYtzvm5vOzOkhenGqjp7UQuYxxNhMKGxScMlnvpzPTChGoaWxTzmK8X
+yaT55rh8EYZIx5EIBm8tfsYJUbQFgNnGSRIKluMTpW8+CqO9uU0V5olkGQIDAQAB
+AoGAAMPlYQ/LyUZccyKhfsaipJAt4B0x3h7qrYTxIH8ZcazEbhhKyt81hPz4YybU
+I0MqZOcvsKuVbsaIbSS1Jb6z8guf9mJDEORhBZfAzKkaj5wZwA997slMLl3W9NRL
+awyse3Xj6SHyqwUsDbnYPwTHqOsurRqnKHeop3MRXZbSeSkCQQD9pT0dSnK5o6DG
+eFP9SnDl/bZ0+9ASaJpkxbkopHmSUAQ517Yu4eDZkGaqCf8BY4WJrUggK0wBL874
+Co62iu1nAkEA0SfbZtthU2pMb9szY/rwsQHpUCMeN0Uw8K5Z6rxrrDqGlCIFNra0
+RleQIwGkV+O7K0IvqxIZXwKgxKEKKZSyfwJBAIWOGBvwM3BkJCfc+/yG0eOIMCZw
+4SKQSZt+MPyhfhH4aAE9AAS3kvl7+1LVaJyGlq3ju/KUWbTWQ5h/lp2vkUkCQG23
+tc1oKc8DRSOsXnIFMnv4X7btJS2jO0AWhg6wVt9bODu++PMxtrHrvy3N77M3QHk5
+2B2qeeqwSzu6qsUTPusCQDnwU5NZWJMqWpnKd8IULXaK6pIKpJtgdNK7E4xCVYHA
+yxxXP/Crot2XznHTZLWsSdgRzc0GuLysclbOo6jIcw4=
+-----END RSA PRIVATE KEY-----
+""")
+
     def test_empty(self):
-        self.fail("write me")
+        """
+        If the given file contains no entries, ``None`` is returned.
+        """
+        path = FilePath(self.mktemp())
+        path.makedirs()
+        empty = path.child(b"empty_known_hosts")
+        empty.touch()
+        self.assertIs(None, _get_entry_from_keyscan(empty))
 
     def test_rsakey(self):
-        self.fail("write me")
+        """
+        If the given file contains a n RSA key entry, its MD5 fingerprint
+        is returned along with the entry itself.
+        """
+        path = FilePath(self.mktemp())
+        path.makedirs()
+        rsa_path = path.child(b"rsa_known_hosts")
+        known_hosts = KnownHostsFile.fromPath(rsa_path)
+        known_hosts.addHostKey(b"example.com", self.RSA_KEY)
+        known_hosts.save()
+
+        self.assertEqual(
+            (self.RSA_KEY.fingerprint(), rsa_path.getContent().strip()),
+            _get_entry_from_keyscan(rsa_path)
+        )

--- a/lae_automation/test/test_initialize.py
+++ b/lae_automation/test/test_initialize.py
@@ -40,3 +40,11 @@ class InitializationTests (TestCase):
         d = self.failUnlessFailure(verify_and_store_serverssh_pubkey(*argtuple),
                                    mismatchfailure.value)
         return d
+
+
+class KeyscanTests(TestCase):
+    def test_empty(self):
+        self.fail("write me")
+
+    def test_rsakey(self):
+        self.fail("write me")

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ mock
 pyOpenSSL
 simplejson
 twisted
+pem
 
 txAWS==0.2.1.post5


### PR DESCRIPTION
Fixes #407 

This removes use of ssh-keygen for extracting a fingerprint.  The replacement is based on Twisted Conch's key APIs which should prove more stable than the OpenSSH command-line tools.