### PR TITLE
Pin the Stripe API version to fix the subscription/subscriptions confusion

### DIFF
--- a/create_stripe_plan.py
+++ b/create_stripe_plan.py
@@ -1,4 +1,4 @@
-import stripe
+from lae_util import stripe
 
 from twisted.python.filepath import FilePath
 
@@ -6,7 +6,6 @@ from lae_automation.config import Config
 
 config = Config('../../secret_config/lae_automation_config.json')
 
-stripe.api_key = FilePath('../../secret_config/stripeapikey').getContent().strip()
 product = config.products[0]
 
 amount = int(product["amount"])
@@ -15,7 +14,7 @@ currency = product["currency"]
 name = product["plan_name"]
 plan_id = product["plan_ID"]
 trial_period_days = int(product["plan_trial_period_days"])
-statement_description = product["statement_description"]
+statement_descriptor = product["statement_description"]
 
 stripe.Plan.create(amount=amount,
                    interval=interval,
@@ -23,4 +22,4 @@ stripe.Plan.create(amount=amount,
                    currency=currency,
                    id=plan_id,
                    trial_period_days=trial_period_days,
-                   statement_description=statement_description)
+                   statement_descriptor=statement_descriptor)

--- a/create_stripe_plan.py
+++ b/create_stripe_plan.py
@@ -6,6 +6,7 @@ from lae_automation.config import Config
 
 config = Config('../../secret_config/lae_automation_config.json')
 
+stripe.api_key = FilePath('../../secret_config/stripeapikey').getContent().strip()
 product = config.products[0]
 
 amount = int(product["amount"])

--- a/full_signup.py
+++ b/full_signup.py
@@ -36,7 +36,7 @@ def main(stdin, flapp_stdout, flapp_stderr):
 
     def errhandler(err):
         fh = flapp_stderr.open('a+')
-        fh.write(repr(err))
+        err.printTraceback(fh)
         fh.close()
         return err
 

--- a/lae_site/handlers/submit_subscription.py
+++ b/lae_site/handlers/submit_subscription.py
@@ -97,7 +97,7 @@ class SubmitSubscriptionHandler(HandlerBase):
                                         email_subject="Stripe unexpected error")
 
     def run_full_signup(self, customer, request):
-        subscription = customer.subscriptions[0]
+        subscription = customer.subscriptions.data[0]
         def when_done(ign):
             service_confirmed_fp = self.basefp.child(SERVICE_CONFIRMED_FILE)
             try:
@@ -155,7 +155,7 @@ class SubmitSubscriptionHandler(HandlerBase):
             return tmpl.render({"errorblock": e.details}).encode('utf-8', 'replace')
 
         # Log that a new subscription has been created (at stripe).
-        subscription = customer.subscriptions[0]
+        subscription = customer.subscriptions.data[0]
         subscriptions_fp = self.basefp.child(SUBSCRIPTIONS_FILE)
         append_record(subscriptions_fp, subscription.id)
         # Initiate the provisioning service

--- a/lae_site/handlers/test/test_submit_subscription.py
+++ b/lae_site/handlers/test/test_submit_subscription.py
@@ -62,7 +62,7 @@ class MockSubscription(object):
 
 class MockCustomer(object):
     def create(self, api_key, card, plan, email):
-        self.subscription = MockSubscription()
+        self.subscriptions = [MockSubscription()]
         self.email = email
         self.id = 'IDSTUB'
         self.init_email = email

--- a/lae_site/handlers/test/test_submit_subscription.py
+++ b/lae_site/handlers/test/test_submit_subscription.py
@@ -59,10 +59,13 @@ class MockSubscription(object):
         self.id = "sub_"+"A"*14
         self.plan = MockPlan()
 
+class MockList(object):
+    def __init__(self, data):
+        self.data = data
 
 class MockCustomer(object):
     def create(self, api_key, card, plan, email):
-        self.subscriptions = [MockSubscription()]
+        self.subscriptions = MockList([MockSubscription()])
         self.email = email
         self.id = 'IDSTUB'
         self.init_email = email
@@ -476,7 +479,7 @@ class TestRenderWithoutExceptions(CommonRenderFixture):
             return _append(self.env_get_template_return_values, self.mock_template)
         self.patch(submit_subscription.env, 'get_template', call_get_template)
         # Note render mockery is handled inside of MockTemplate
-        
+
         self.subscription_handler.render(MockRequest(REQUESTARGS, method='POST'))
 
     def test_get_creation_parameters_calls(self):

--- a/lae_util/__init__.py
+++ b/lae_util/__init__.py
@@ -1,0 +1,8 @@
+
+import stripe
+# Pin the Stripe API version to a known value.  This will need to be
+# updated from time to time (alongside any code changes that may be
+# necessary to retain compatibility with a new Stripe API version).
+#
+# This overrides the Stripe account-wide API version setting.
+stripe.api_version = '2016-07-06'


### PR DESCRIPTION
Fixes #412 

This pins the API version used to the version that is current as of this PR.  It changes the application code to use the `subscriptions` list instead of the (now removed) `subscription` scalar.