### PR TITLE
Clean up main.py command line argument parsing

### DIFF
--- a/lae_site/handlers/__init__.py
+++ b/lae_site/handlers/__init__.py
@@ -9,16 +9,16 @@ from lae_site.handlers.web import JinjaHandler
 from lae_site.handlers.submit_subscription import SubmitSubscriptionHandler
 
 
-def make_site(basefp, config):
+def make_site(email_path, stripe_api_key, service_confirmed_path, subscriptions_path, site_logs_path):
     resource = JinjaHandler('index.html')
     resource.putChild('static', File('content/static'))
     resource.putChild('blog', File('content/blog'))
-    resource.putChild('collect-email', CollectEmailHandler(basefp))
+    resource.putChild('collect-email', CollectEmailHandler(email_path))
     resource.putChild('signup', Redirect("/"))
-    resource.putChild('submit-subscription', SubmitSubscriptionHandler(basefp))
+    resource.putChild('submit-subscription', SubmitSubscriptionHandler(stripe_api_key, service_confirmed_path, subscriptions_path))
     resource.putChild('support', Redirect("https://leastauthority.zendesk.com/home"))
 
-    site = Site(resource, logPath=basefp.child('sitelogs').path)
+    site = Site(resource, logPath=site_logs_path.path)
     site.displayTracebacks = True
     return site
 

--- a/lae_site/handlers/emailcollector.py
+++ b/lae_site/handlers/emailcollector.py
@@ -10,7 +10,6 @@ from lae_util.send_email import send_plain_email, FROM_EMAIL, FROM_ADDRESS
 from lae_site.handlers.web import env
 from lae_site.handlers.main import HandlerBase
 
-EMAILS_FILE = 'emails.csv'
 VALID_EMAIL_RE = re.compile("[^@]+@[^@]+")
 ACTIVE_PRODUCTS = set(['s4'])
 
@@ -32,10 +31,10 @@ The Least Authority Enterprises team
 
 
 class CollectEmailHandler(HandlerBase):
-    def __init__(self, basefp, out=None):
+    def __init__(self, email_path, out=None):
         HandlerBase.__init__(self, out=out)
         self._logger_helper(__name__)
-        self.basefp = basefp
+        self.email_path = email_path
 
     def render(self, request):
         print >>self.out, "Yay, another potential customer:", request.args
@@ -47,7 +46,7 @@ class CollectEmailHandler(HandlerBase):
         email = self.get_arg(request, 'Email')
         productfullname = self.get_arg(request, 'ProductFullName')
 
-        append_record(self.basefp.child(EMAILS_FILE), email, productname)
+        append_record(self.email_path, email, productname)
 
         request.setResponseCode(200)
 

--- a/lae_site/main.py
+++ b/lae_site/main.py
@@ -15,6 +15,7 @@ import logging
 import pem
 
 from twisted.internet import ssl
+from twisted.internet.defer import Deferred
 from twisted.python.usage import UsageError, Options
 from twisted.python.filepath import FilePath
 
@@ -92,6 +93,7 @@ def main(reactor, *argv):
             not o["noredirect"], o["redirectport"],
         )
     )
+    d.addCallback(lambda ignored: Deferred())
     return d
 
 def start_site(reactor, site, port, ssl_enabled, redirect, redirect_port):

--- a/lae_site/main.py
+++ b/lae_site/main.py
@@ -38,8 +38,8 @@ class SiteOptions(Options):
         ("service-confirmed-path", None, None, "A path to a file to which confirmed-service subscription details will be appended.", FilePath),
         ("site-logs-path", None, None, "A path to a file to which HTTP logs for the site will be written.", FilePath),
 
-        ("port", None, "443", "The TCP port number on which to listen for TLS/HTTP requests.", int),
-        ("redirectport", "80", None, "A TCP port number on which to run a redirect-to-TLS site.", int),
+        ("port", None, 443, "The TCP port number on which to listen for TLS/HTTP requests.", int),
+        ("redirectport", None, 80, "A TCP port number on which to run a redirect-to-TLS site.", int),
     ]
 
 

--- a/lae_site/main.py
+++ b/lae_site/main.py
@@ -77,7 +77,7 @@ def main(reactor, *argv):
     d = start(o["signup-furl-path"])
     d.addCallback(
         lambda ignored: make_site(
-            o["email-path"],
+            o["interest-path"],
             o["stripe-api-key-path"].getContent().strip(),
             o["service-confirmed-path"],
             o["subscriptions-path"],

--- a/lae_site/test/test_site.py
+++ b/lae_site/test/test_site.py
@@ -1,6 +1,5 @@
 
 import string
-from cStringIO import StringIO
 
 import mock
 
@@ -9,16 +8,22 @@ from twisted.trial.unittest import TestCase
 from twisted.web.http import OK, NOT_FOUND
 from twisted.web.server import unquote
 
-from lae_site.config import Config
 from lae_site.handlers import make_site
 
 
 SITE_CONFIG_JSON = """{}"""
+STRIPE_API_KEY = b"abcdef"
 
 class Site(TestCase):
     def test_site(self):
-        config = Config(StringIO(SITE_CONFIG_JSON))
-        site = make_site(FilePath('.'), config)
+        root = FilePath(self.mktemp())
+        site = make_site(
+            root.child(b"emails.csv"),
+            STRIPE_API_KEY,
+            root.child(b"confirmed.csv"),
+            root.child(b"subscriptions.csv"),
+            root.child("sitelogs"),
+        )
 
         (req, resp) = self._mock_request(site, '/', 'GET')
         req.setResponseCode.assert_called_with(OK)

--- a/runsite.sh
+++ b/runsite.sh
@@ -4,7 +4,25 @@ set -e
 cd $(readlink -f $(dirname $0))
 flappserver restart `pwd`/flapp
 sleep 2
-cmd="python -u '`pwd`/lae_site/main.py'"
+
+SECRETS="${PWD}/../secret_config"
+LOGS="${PWD}/.."
+
+cmd="\
+python -u ${PWD}/lae_site/main.py \
+\
+--signup-furl-path ${SECRETS}/signup.furl \
+--stripe-api-key-path ${SECRETS}/stripeapikey \
+\
+--site-logs-path ${LOGS}/sitelogs \
+--interest-path ${LOGS}/emails.csv \
+--subscriptions-path ${LOGS}/subscriptions.csv \
+--service-confirmed-path ${LOGS}/service_confirmed.csv \
+\
+--port 8443 \
+--redirectport 8080 \
+
+"
 pattern="python -u `pwd`/lae_site/main.py"
 pids=$(pgrep -fl "$pattern" |cut -f1 -d' ')
 if [ "$pids" != "" ]; then

--- a/runsite.sh
+++ b/runsite.sh
@@ -19,8 +19,8 @@ python -u ${PWD}/lae_site/main.py \
 --subscriptions-path ${LOGS}/subscriptions.csv \
 --service-confirmed-path ${LOGS}/service_confirmed.csv \
 \
---port 8443 \
---redirectport 8080 \
+--port 443 \
+--redirectport 80 \
 
 "
 pattern="python -u `pwd`/lae_site/main.py"


### PR DESCRIPTION
Fixes #416 

Apart from cleaning things up, this parameterizes a bunch of the inputs and outputs to the web server - making it easier to change how the deployment works (like putting the web server in a container).