### PR TITLE
Add magic-wormhole relay and transit servers to the S4 service.

### DIFF
--- a/docker/Dockerfile.magicwormhole-relay
+++ b/docker/Dockerfile.magicwormhole-relay
@@ -1,0 +1,64 @@
+#
+# Attempts are made to follow the guidelines at
+# https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/
+#
+
+# Use the same base image as Dockerfile.infrastructure so we can share
+# it with those images.
+FROM library/ubuntu:14.04.5
+
+# If there are security updates for any of the packages we install,
+# bump the date in this environment variable to invalidate the Docker
+# build cache and force installation of the new packages.  Otherwise,
+# Docker's image/layer cache may prevent the security update from
+# being retrieved.
+ENV SECURITY_UPDATES="2016-11-22"
+
+# We'll do an upgrade because the base Ubuntu image isn't guaranteed
+# to include the latest security updates.  This is counter to best
+# practice recommendations but security updates are important.
+RUN apt-get update && \
+    apt-get install -y unattended-upgrades && \
+    unattended-upgrade --minimal_upgrade_steps && \
+rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y \
+    python-dev \
+    libffi-dev \
+    openssl \
+    libssl-dev \
+    \
+    python-virtualenv \
+&& rm -rf /var/lib/apt/lists/*
+
+# Create a virtualenv into which to install magicwormhole in to.
+RUN virtualenv /app/env
+
+# Get a newer version of pip.
+RUN /app/env/bin/pip install --upgrade pip
+
+# Create the website account, the user as which the infrastructure
+# server will run.
+ENV WORMHOLE_USER_NAME="wormhole"
+
+# Force the allocated user to uid 1000 because we hard-code 1000
+# below.
+RUN adduser --uid 1000 --disabled-password --gecos "" "${WORMHOLE_USER_NAME}"
+
+# Run the application with this working directory.
+WORKDIR /app/run
+
+# And give it to the user the application will run as.
+RUN chown ${WORMHOLE_USER_NAME} /app/run
+
+# Get the app we want to run!
+RUN /app/env/bin/pip install magic-wormhole==0.8.1
+
+# Facilitate network connections to the application.
+EXPOSE 4000
+
+USER 1000
+
+CMD env && /app/env/bin/wormhole-server start \
+					--rendezvous tcp:4000 \
+					--no-daemon

--- a/docker/Dockerfile.magicwormhole-relay
+++ b/docker/Dockerfile.magicwormhole-relay
@@ -17,12 +17,12 @@ ENV SECURITY_UPDATES="2016-11-22"
 # We'll do an upgrade because the base Ubuntu image isn't guaranteed
 # to include the latest security updates.  This is counter to best
 # practice recommendations but security updates are important.
-RUN apt-get update && \
+RUN DEBIAN_FRONTEND="noninteractive" apt-get update && \
     apt-get install -y unattended-upgrades && \
     unattended-upgrade --minimal_upgrade_steps && \
 rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get install -y \
+RUN DEBIAN_FRONTEND="noninteractive" apt-get update && apt-get install -y \
     python-dev \
     libffi-dev \
     openssl \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,3 +5,5 @@ LEASTAUTHORITY=$(dirname $(dirname $0))
 docker build -t leastauthority/infrastructure -f "${LEASTAUTHORITY}"/docker/Dockerfile.infrastructure "${LEASTAUTHORITY}"
 docker build -t leastauthority/flapp -f "${LEASTAUTHORITY}"/docker/Dockerfile.flapp "${LEASTAUTHORITY}"
 docker build -t leastauthority/web -f "${LEASTAUTHORITY}"/docker/Dockerfile.web "${LEASTAUTHORITY}"
+
+docker build -t leastauthority/magicwormhole -f "${LEASTAUTHORITY}"/docker/Dockerfile.magicwormhole-relay "${LEASTAUTHORITY}"/docker

--- a/k8s/build.sh
+++ b/k8s/build.sh
@@ -51,6 +51,7 @@ ${EXEC} bash -e -x -c '
     # with the tag given in the environment.
     docker tag leastauthority/web 127.0.0.1:30000/leastauthority/web:"${DOCKER_TAG}"
     docker tag leastauthority/flapp 127.0.0.1:30000/leastauthority/flapp:"${DOCKER_TAG}"
+    docker tag leastauthority/magicwormhole 127.0.0.1:30000/leastauthority/magicwormhole:"${DOCKER_TAG}"
 
     # Clean up the last portforwarder, if necessary.
     [ -e /tmp/portforward.pid ] && kill $(cat /tmp/portforward.pid) || /bin/true
@@ -66,6 +67,7 @@ ${EXEC} bash -e -x -c '
     # And push them.
     docker push 127.0.0.1:30000/leastauthority/web:"${DOCKER_TAG}"
     docker push 127.0.0.1:30000/leastauthority/flapp:"${DOCKER_TAG}"
+    docker push 127.0.0.1:30000/leastauthority/magicwormhole:"${DOCKER_TAG}"
 
     echo "Tagged images with ${DOCKER_TAG}."
 '

--- a/k8s/infrastructure.yaml
+++ b/k8s/infrastructure.yaml
@@ -41,6 +41,12 @@ spec:
     port: 80
     targetPort: 8080
     protocol: 'TCP'
+  - name: 'wormhole-relay'
+    port: 4000
+    protocol: 'TCP'
+  - name: 'wormhole-transit-relay'
+    port: 4001
+    protocol: 'TCP'
 ---
 # Read about deployments at
 # http://kubernetes.io/docs/user-guide/deployments/
@@ -113,6 +119,21 @@ spec:
         volumeMounts:
         - mountPath: '/app/data'
           name: 'flapp-data'
+
+      # This is the wormhole relay server.  It will help people get
+      # introduced to their grid, someday.
+      - name: 'wormhole-relay'
+        # This image is hosted by the cluster-private registry.
+        # XXX This avoids `localhost` because different k8s
+        # deployments seem to have different behavior with respect to
+        # localhost resolution for the purposes of image pulls.
+        # Specifically, kops deploys a cluster where localhost
+        # resolves to [::1] where the registry is not available.
+        image: '127.0.0.1:30000/leastauthority/magicwormhole:e9b33b30f4ac5330e74c699da9c1953b99c30d9c'
+        ports:
+        # We just happen to know this is the ports this container listens on.
+        - containerPort: 4000
+        - containerPort: 4001
 ---
 # Read about PersistentVolumeClaims at
 # http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
This expands the k8s configuration for the s4-infrastructure deployment to include magic wormhole servers.  It exposes both the rendezvous and transit relay servers.  It makes no attempt to preserve state for the server.  This probably means that restarting the servers (as happens if we want to update the s4-infrastructure deployment in any way) will break half-open wormholes.  If that's a concern we can build on this work later to add a volume so the server has a place for persistent storage.
