### PR TITLE
Ability to configure Tahoe-LAFS with log and stats gatherer furls

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -ex
 
 LEASTAUTHORITY=$(dirname $(dirname $0))
 

--- a/full_signup.py
+++ b/full_signup.py
@@ -71,6 +71,9 @@ def activate(secrets_dir, automation_config_path, server_info_path, stdin, flapp
         amiimageid=product['ami_image_id'],
         instancesize=product['instance_size'],
 
+        log_gatherer_furl=config.other.get("log_gatherer_furl") or None,
+        stats_gatherer_furl=config.other.get("stats_gatherer_furl") or None,
+
         usertoken=None,
         producttoken=None,
 

--- a/full_signup.py
+++ b/full_signup.py
@@ -60,6 +60,7 @@ def activate(secrets_dir, automation_config_path, server_info_path, stdin, flapp
     config = Config(automation_config_path.path)
     product = lookup_product(config, plan_id)
     fullname = product['plan_name']
+
     with flapp_stdout_path.open("a") as stdout:
         print >>stdout, "Signing up customer for %s..." % (fullname,)
 
@@ -92,7 +93,6 @@ def activate(secrets_dir, automation_config_path, server_info_path, stdin, flapp
         monitor_pubkey_path=config.other["monitor_pubkey_path"],
         monitor_privkey_path=config.other["monitor_privkey_path"],
     )
-
     d = defer.succeed(None)
     d.addCallback(lambda ign: activate_subscribed_service(
         deploy_config, signup_stdout, signup_stderr, signup_log_fp.path,

--- a/k8s/build.sh
+++ b/k8s/build.sh
@@ -23,7 +23,7 @@ ${EXEC} bash -e -x -c '
 # Get a fresh, clean space to work in.
 TEMP=$(${EXEC} bash -c 'mktemp -d')
 
-${EXEC} bash -e -x -c '
+${EXEC} bash -ex -c '
     # Clone the git branch variable to the remote environment.
     GIT_BRANCH="'"${GIT_BRANCH}"'"
     WORKDIR="'"${TEMP}"'"

--- a/lae_automation/configure-tahoe
+++ b/lae_automation/configure-tahoe
@@ -80,6 +80,8 @@ def main():
             introducer_furl=section["introducer_furl"],
             s3_access_key_id=section["s3_access_key_id"],
             s3_secret_key=section["s3_secret_key"],
+            log_gatherer_furl=section.get("log_gatherer_furl", ""),
+            stats_gatherer_furl=section.get("stats_gatherer_furl", ""),
         )
 
 
@@ -97,7 +99,8 @@ def configure_introducer(introducer, port, node_pem):
 def configure_storage(
         storage, port, node_pem, node_privkey,
         bucket_name, publichost, privatehost, introducer_furl,
-        s3_access_key_id, s3_secret_key
+        s3_access_key_id, s3_secret_key,
+        log_gatherer_furl, stats_gatherer_furl,
 ):
     storage.child(b"client.port").setContent(
         u"{}".format(port).encode("ascii")
@@ -115,8 +118,8 @@ def configure_storage(
         introducer_furl=introducer_furl,
         s3_access_key_id=s3_access_key_id,
         bucket_name=bucket_name,
-        incident_gatherer_furl="",
-        stats_gatherer_furl="",
+        incident_gatherer_furl=log_gatherer_furl,
+        stats_gatherer_furl=stats_gatherer_furl,
     )
 
     storage.child(b"tahoe.cfg").setContent(tahoe_cfg)

--- a/lae_automation/configure-tahoe
+++ b/lae_automation/configure-tahoe
@@ -19,7 +19,26 @@ from json import load
 
 from twisted.python.filepath import FilePath
 
-TAHOE_CFG_TEMPLATE = """# -*- mode: conf; coding: utf-8 -*-
+INTRODUCER_CFG_TEMPLATE = """# -*- mode: conf; coding: utf-8 -*-
+
+# This file controls the configuration of the Tahoe node that
+# lives in this directory. It is only read at node startup.
+# For details about the keys that can be set here, please
+# read the 'docs/configuration.rst' file that came with your
+# Tahoe installation.
+
+
+[node]
+nickname =
+web.port =
+web.static = public_html
+log_gatherer.furl = %(log_gatherer_furl)s
+
+[client]
+stats_gatherer.furl = %(stats_gatherer_furl)s
+"""
+
+STORAGE_CFG_TEMPLATE = """# -*- mode: conf; coding: utf-8 -*-
 
 # This file controls the configuration of the Tahoe node that
 # lives in this directory. It is only read at node startup.
@@ -66,6 +85,8 @@ def main():
             introducer=FilePath(section["root"]),
             port=section["port"],
             node_pem=section["node_pem"],
+            log_gatherer_furl=section.get("log_gatherer_furl", ""),
+            stats_gatherer_furl=section.get("stats_gatherer_furl", ""),
         )
     if "storage" in config:
         section = config["storage"]
@@ -85,7 +106,10 @@ def main():
         )
 
 
-def configure_introducer(introducer, port, node_pem):
+def configure_introducer(
+        introducer, port, node_pem,
+        log_gatherer_furl, stats_gatherer_furl,
+):
     force_remove(introducer.child(b"introducer.furl"))
     force_remove(introducer.descendant((b"private", b"introducer.furl")))
     force_remove(introducer.child(b"logport.furl"))
@@ -94,6 +118,11 @@ def configure_introducer(introducer, port, node_pem):
         u"{}".format(port).encode("ascii")
     )
     configure_secrets(introducer, node_pem)
+    tahoe_cfg = INTRODUCER_CFG_TEMPLATE % dict(
+        log_gatherer_furl=log_gatherer_furl,
+        stats_gatherer_furl=stats_gatherer_furl,
+    )
+    introducer.child(b"tahoe.cfg").setContent(tahoe_cfg)
 
 
 def configure_storage(
@@ -111,7 +140,7 @@ def configure_storage(
         storage.descendant((b"private", "node.privkey")).setContent(node_privkey)
     storage.descendant((b"private", "s3secret")).setContent(s3_secret_key)
 
-    tahoe_cfg = TAHOE_CFG_TEMPLATE % dict(
+    tahoe_cfg = STORAGE_CFG_TEMPLATE % dict(
         nickname=bucket_name,
         publichost=publichost,
         privatehost=privatehost,

--- a/lae_automation/server.py
+++ b/lae_automation/server.py
@@ -354,12 +354,20 @@ def marshal_tahoe_configuration(
         storage_pem, storage_privkey,
         bucket_name, publichost, privatehost, introducer_furl,
         s3_access_key_id, s3_secret_key,
+        log_gatherer_furl=None,
+        stats_gatherer_furl=None,
 ):
+    if log_gatherer_furl is None:
+        log_gatherer_furl = ""
+    if stats_gatherer_furl is None:
+        stats_gatherer_furl = ""
     return dict(
         introducer=dict(
             root=INTRODUCER_ROOT,
             port=INTRODUCER_PORT,
             node_pem=introducer_pem,
+            log_gatherer_furl=log_gatherer_furl,
+            stats_gatherer_furl=stats_gatherer_furl,
         ),
         storage=dict(
             root=STORAGE_ROOT,
@@ -372,6 +380,8 @@ def marshal_tahoe_configuration(
             introducer_furl=introducer_furl,
             s3_access_key_id=s3_access_key_id,
             s3_secret_key=s3_secret_key,
+            log_gatherer_furl=log_gatherer_furl,
+            stats_gatherer_furl=stats_gatherer_furl,
         ),
     )
 

--- a/lae_automation/server.py
+++ b/lae_automation/server.py
@@ -385,31 +385,32 @@ def marshal_tahoe_configuration(
         ),
     )
 
-def bounce_server(publichost, admin_privkey_path, privatehost, s3_access_key_id, s3_secret_key,
-                  user_token, product_token, bucket_name, oldsecrets, stdout, stderr, secretsfile,
+def bounce_server(deploy_config, publichost, admin_privkey_path, privatehost, stdout, stderr,
                   configpath=None):
     set_host_and_key(publichost, admin_privkey_path, username="customer")
 
-    if oldsecrets is None:
+    if deploy_config.oldsecrets is None:
         configuration = new_tahoe_configuration(
-            nickname=bucket_name,
-            bucket_name=bucket_name,
+            nickname=deploy_config.bucketname,
+            bucket_name=deploy_config.bucketname,
             publichost=publichost,
             privatehost=privatehost,
-            s3_access_key_id=s3_access_key_id,
-            s3_secret_key=s3_secret_key,
+            s3_access_key_id=deploy_config.s3_access_key_id,
+            s3_secret_key=deploy_config.s3_secret_key,
         )
     else:
         configuration = marshal_tahoe_configuration(
-            introducer_pem=oldsecrets["introducer_node_pem"],
-            storage_pem=oldsecrets["storageserver_node_pem"],
-            storage_privkey=oldsecrets["server_node_privkey"],
-            bucket_name=bucket_name,
+            introducer_pem=deploy_config.oldsecrets["introducer_node_pem"],
+            storage_pem=deploy_config.oldsecrets["storageserver_node_pem"],
+            storage_privkey=deploy_config.oldsecrets["server_node_privkey"],
+            bucket_name=deploy_config.bucketname,
             publichost=publichost,
             privatehost=privatehost,
-            introducer_furl=oldsecrets["internal_introducer_furl"],
-            s3_access_key_id=s3_access_key_id,
-            s3_secret_key=s3_secret_key,
+            introducer_furl=deploy_config.oldsecrets["internal_introducer_furl"],
+            s3_access_key_id=deploy_config.s3_access_key_id,
+            s3_secret_key=deploy_config.s3_secret_key,
+            log_gatherer_furl=deploy_config.log_gatherer_furl,
+            stats_gatherer_furl=deploy_config.stats_gatherer_furl,
         )
 
     api.put(
@@ -453,8 +454,8 @@ shares.total = 1
 
 """ % (external_introducer_furl,)
 
-    print >>secretsfile, simplejson.dumps(secrets_to_legacy_format(configuration))
-    secretsfile.flush()
+    print >>deploy_config.secretsfile, simplejson.dumps(secrets_to_legacy_format(configuration))
+    deploy_config.secretsfile.flush()
 
     return external_introducer_furl
 

--- a/lae_automation/server.py
+++ b/lae_automation/server.py
@@ -4,7 +4,7 @@
 -- These are transferred to the new EC2 instance in /home/customer/.ssh, and /home/ubuntu/.ssh
 """
 
-import os, sys, base64, simplejson, subprocess
+import os, simplejson, subprocess
 from datetime import datetime
 utcnow = datetime.utcnow
 
@@ -23,8 +23,6 @@ from twisted.python.filepath import FilePath
 from foolscap.api import Tub
 
 from allmydata.util import keyutil
-
-from lae_util.streams import LoggingStream
 
 class PathFormatError(Exception):
     pass

--- a/lae_automation/signup.py
+++ b/lae_automation/signup.py
@@ -129,7 +129,10 @@ def and_(*v):
             validator(inst, attr, value)
     return _and
 
-validate_furl = and_(attr.validators.instance_of(str), decode_furl)
+validate_furl = and_(
+    attr.validators.instance_of(str),
+    lambda inst, attr, value: decode_furl(value),
+)
 
 @attr.s(frozen=True)
 class DeploymentConfiguration(object):

--- a/lae_automation/test/strategies.py
+++ b/lae_automation/test/strategies.py
@@ -133,7 +133,14 @@ def introducer_configuration():
         "root": absolute_path(),
         "port": port_number(),
         "node_pem": node_pem(),
-    })
+
+        "log-gatherer-swissnum": swissnum(),
+        "stats-gatherer-swissnum": swissnum(),
+    }).map(
+        _add_furl("log-gatherer-swissnum", "log_gatherer_furl")
+    ).map(
+        _add_furl("stats-gatherer-swissnum", "stats_gatherer_furl")
+    )
 
 def storage_configuration(keypair=keyutil.make_keypair()):
     return strategies.fixed_dictionaries({

--- a/lae_automation/test/strategies.py
+++ b/lae_automation/test/strategies.py
@@ -82,6 +82,21 @@ def port_number():
         min_value=0, max_value=2 ** 16 - 1
     )
 
+def furl():
+    tubID = Tub(node_pem().example()).getTubID()
+    # XXX Not well factored probably.
+    return strategies.builds(
+        lambda pem, addr, port, swissnum: encode_furl(
+            Tub(pem).getTubID(),
+            ["{}:{}".format(addr, port)],
+            swissnum,
+        ),
+        node_pem(),
+        ipv4_address(),
+        port_number(),
+        swissnum(),
+    )
+
 def _add_furl(swissnum, target):
     def add(config):
         num = config.pop(swissnum)

--- a/lae_automation/test/strategies.py
+++ b/lae_automation/test/strategies.py
@@ -1,3 +1,11 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
+"""
+This module implements various Hypothesis strategies useful for
+QuickCheck-style testing of ``lae_automation`` APIs.
+"""
+
 from string import uppercase, lowercase, letters, digits
 from base64 import b32encode
 

--- a/lae_automation/test/strategies.py
+++ b/lae_automation/test/strategies.py
@@ -1,0 +1,161 @@
+from string import uppercase, lowercase, letters, digits
+from base64 import b32encode
+
+from hypothesis import strategies
+
+from allmydata.util import keyutil
+
+from lae_automation import signup
+
+from foolscap.api import Tub
+from foolscap.furl import encode_furl
+
+_BASE32_CHARS = lowercase + "234567"
+
+def nickname():
+    return strategies.text(
+        alphabet=_BASE32_CHARS, min_size=24, max_size=24
+    )
+
+def subscription_id():
+    return strategies.binary(min_size=10, max_size=10).map(
+        lambda b: b'sub_' + b.encode('base64').strip('_')
+    )
+
+def customer_id():
+    return strategies.binary(min_size=10, max_size=10).map(
+        lambda b: b'cus_' + b.encode('base64').strip('_')
+    )
+
+def bucket_name():
+    return strategies.tuples(
+        subscription_id(),
+        customer_id(),
+    ).map(
+        lambda (s, c): signup.get_bucket_name(s, c)
+    )
+
+def ipv4_address():
+    return strategies.lists(
+        elements=strategies.integers(min_value=0, max_value=255),
+        min_size=4, max_size=4,
+    ).map(
+        lambda parts: "{}.{}.{}.{}".format(*parts)
+    )
+
+def aws_access_key_id():
+    return strategies.text(
+        alphabet=uppercase + digits,
+        min_size=20,
+        max_size=20,
+    )
+
+def aws_secret_key():
+    # Maybe it's base64 encoded?
+    return strategies.text(
+        alphabet=letters + digits + "/+",
+        min_size=40,
+        max_size=40,
+    )
+
+def relative_path():
+    return strategies.characters(
+        blacklist_characters=[u"\0", u"/"]
+    )
+
+def absolute_path():
+    return relative_path().map(
+        lambda p: u"/" + p
+    )
+
+
+def swissnum():
+    return strategies.binary(
+        min_size=Tub.NAMEBITS / 8,
+        max_size=Tub.NAMEBITS/  8,
+    ).map(
+        lambda b: b32encode(b).rstrip("=").lower()
+    )
+
+def port_number():
+    return strategies.integers(
+        min_value=0, max_value=2 ** 16 - 1
+    )
+
+def _add_furl(swissnum, target):
+    def add(config):
+        num = config.pop(swissnum)
+        tubID = Tub(config["node_pem"]).getTubID()
+        config[target] = encode_furl(tubID, ["127.0.0.1:12345"], num)
+        return config
+    return add
+
+def node_pem():
+    # XXX Slow to generate these.  Variations probably matter little.
+    # Still, they might.  Do something better.
+    NODE_PEM = """\
+-----BEGIN CERTIFICATE-----
+MIICjzCCAfgCAQEwDQYJKoZIhvcNAQEEBQAwgY8xEDAOBgNVBAsTB2V4YW1wbGUx
+EDAOBgNVBAoTB2V4YW1wbGUxFDASBgNVBAMTC2V4YW1wbGUuY29tMRAwDgYDVQQI
+EwdleGFtcGxlMQswCQYDVQQGEwJVUzEiMCAGCSqGSIb3DQEJARYTZXhhbXBsZUBl
+eGFtcGxlLmNvbTEQMA4GA1UEBxMHZXhhbXBsZTAeFw0xNDAyMTIwMDMxMzlaFw0x
+NTAyMTIwMDMxMzlaMIGPMRAwDgYDVQQLEwdleGFtcGxlMRAwDgYDVQQKEwdleGFt
+cGxlMRQwEgYDVQQDEwtleGFtcGxlLmNvbTEQMA4GA1UECBMHZXhhbXBsZTELMAkG
+A1UEBhMCVVMxIjAgBgkqhkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAO
+BgNVBAcTB2V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKkRahIc
+Fp0V44QYpO9ue7mjZNbZYPAC8caoQC1jUgL42CT40PcoOiZWLgRk+Qw6P7PoJzO/
+T4ufK0qoPUJm1jErDRWy9eWlGLE0grPECM+jxFfLXxJLKdPtuwMA8Ip72JMirFN5
+Y/JTBZOR3j5a/mbY5tcRqgffKxm4QQegnhiBAgMBAAEwDQYJKoZIhvcNAQEEBQAD
+gYEAWANPpp985nXMoIwHlsSMm8ijkk7XQU3oioCYDcM6pLT+mvBDe1mZc8mUlrWy
+Zo/lT6HF44SHIZ0zCgPYwTpWV6C0K+/kKlYBERZ3ajrzGf5ACfUTNyk5P81C68mc
+9fQ7lhq1iuNKzVh8b746Z4ufn6iI1VygnyOQ1hZ/lOX56TA=
+-----END CERTIFICATE-----
+-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQCpEWoSHBadFeOEGKTvbnu5o2TW2WDwAvHGqEAtY1IC+Ngk+ND3
+KDomVi4EZPkMOj+z6Cczv0+LnytKqD1CZtYxKw0VsvXlpRixNIKzxAjPo8RXy18S
+SynT7bsDAPCKe9iTIqxTeWPyUwWTkd4+Wv5m2ObXEaoH3ysZuEEHoJ4YgQIDAQAB
+AoGBAIHNSO6WehYolAD7GsZowL0J4YXCZ1ZeLFolGwC93F1DyE66aVUYoWyFhdcB
+3uOwZPAvMMnd+6hqj8ZF3KJ6ab8eSq3hQQqm4EKHPN2DHHQPWppjWsFtUjG6P4FJ
+tuHu0JD0u10LxdyW240fcptdorAl+e9g6uphCpQ/9h5TgehBAkEA2iLbbp/MM1O8
+Foz+JXY1FfNIgh67Di1BuG8asnX7lsPXI/HsNHPevvOxBbJLh0NEB4AW7Lva0pHH
+DaE+YPPLPQJBAMZqJ87+6iC8V3pRRDi+pfjZ8cRFBIJtbKMloP02/k9dEHeNepZO
+5EcztYPZbgNC6U01ZD5Gyhnc9t5tPfSg5pUCQDASnH9NsifhnULvAZdp7JsQyXr7
+oMeoC6LEwYJw4+g+8qvWRfLtUjqM5AdYWrLNjTGF9gdoAvqC6/ZCAchGEhUCQE/A
+P3v+DlFWIrsxiwBb8Q5TW9AOBb//B5mT+F+PCS0RNRs4rLtZvnu4Fw+GB6gb7vZv
+rXkyru0yWbARrMN1IPkCQQCXNEoKmNSgFOCruE6i7vjkdllkv+KdXQ13l305qlHC
+OzEHlEY+wXPu5R9v3tt2Ktfvfm2Mpfr9Gn+6CUXYn/+P
+-----END RSA PRIVATE KEY-----
+"""
+    return strategies.sampled_from([NODE_PEM])
+
+def introducer_configuration():
+    return strategies.fixed_dictionaries({
+        "root": absolute_path(),
+        "port": port_number(),
+        "node_pem": node_pem(),
+    })
+
+def storage_configuration(keypair=keyutil.make_keypair()):
+    return strategies.fixed_dictionaries({
+        "root": absolute_path(),
+        "port": port_number(),
+        "node_pem": node_pem(),
+        # Uses real randomness.  Should parameterize the prng.
+        "node_privkey": strategies.sampled_from([keypair[0]]),
+
+        "bucket_name": bucket_name(),
+        "publichost": ipv4_address(),
+        "privatehost": ipv4_address(),
+        "s3_access_key_id": aws_access_key_id(),
+        "s3_secret_key": aws_secret_key(),
+
+        "introducer-swissnum": swissnum(),
+        "log-gatherer-swissnum": swissnum(),
+        "stats-gatherer-swissnum": swissnum(),
+    }).map(
+        _add_furl("introducer-swissnum", "introducer_furl")
+    ).map(
+        _add_furl("log-gatherer-swissnum", "log_gatherer_furl")
+    ).map(
+        _add_furl("stats-gatherer-swissnum", "stats_gatherer_furl")
+    )

--- a/lae_automation/test/test_configure_tahoe.py
+++ b/lae_automation/test/test_configure_tahoe.py
@@ -1,0 +1,131 @@
+from sys import executable
+from tempfile import mkstemp, mkdtemp
+from os import fdopen
+from json import dumps
+from subprocess import check_call
+from ConfigParser import SafeConfigParser
+
+from hypothesis import given, settings
+
+from testtools import TestCase
+from testtools.matchers import AfterPreprocessing, Equals, AllMatch
+
+from fixtures import Fixture
+
+from twisted.python.filepath import FilePath
+
+from .strategies import introducer_configuration, storage_configuration
+
+CONFIGURE_TAHOE = FilePath(__file__).parent().parent().child(b"configure-tahoe")
+
+# Parent settings for tests that don't need to discover a huge number
+# of successful examples to be considered a success.
+simple = settings(max_examples=5)
+
+def configure_tahoe(configuration):
+    fd, name = mkstemp()
+    with fdopen(fd, "w+") as fObj:
+        fObj.write(dumps(configuration))
+        fObj.seek(0)
+        # Launch it with sys.executable so it gets the same Python
+        # environment, if we are in a virtualenv, as the test process.
+        check_call([executable, CONFIGURE_TAHOE.path], stdin=fObj)
+
+
+def hasConfiguration(fields):
+    expected_fields = sorted(fields)
+
+    def _readConfig(config_path):
+        config = SafeConfigParser()
+        config.readfp(config_path.open())
+        actual_fields = sorted(
+            (section, field, config.get(section, field))
+            for (section, field, _)
+            in expected_fields
+        )
+        return actual_fields
+    return AfterPreprocessing(_readConfig, Equals(expected_fields))
+
+
+class TahoeNodes(Fixture):
+    def __init__(self, root):
+        Fixture.__init__(self)
+        self.root = root
+
+    def _setUp(self):
+        self.nodes = FilePath(self.root)
+        self.introducer = self.nodes.child(b"introducer")
+        self.introducer.makedirs()
+        self.storage = self.nodes.child(b"storage")
+        self.storage.makedirs()
+
+
+class ConfigureTahoeTests(TestCase):
+    """
+    Tests for the command-line ``configure-tahoe`` tool.
+    """
+    def setUp(self):
+        TestCase.setUp(self)
+        self.nodes = self.useFixture(TahoeNodes(mkdtemp()))
+
+    @given(introducer_configuration(), storage_configuration())
+    @settings(parent=simple)
+    def test_gatherers_missing(self, introducer_config, storage_config):
+        """
+        If the log and stats gatherers are not given, the storage and
+        introducer configurations are written with empty strings for
+        these fields.
+        """
+        introducer_config["root"] = self.nodes.introducer.path
+        storage_config["root"] = self.nodes.storage.path
+
+        for config in [introducer_config, storage_config]:
+            for gatherer in {"log", "stats"}:
+                config.pop(gatherer + "_gatherer_furl", None)
+
+
+        config = dict(introducer=introducer_config, storage=storage_config)
+        configure_tahoe(config)
+
+        config_files = [
+            self.nodes.introducer.child(b"tahoe.cfg"),
+            self.nodes.storage.child(b"tahoe.cfg"),
+        ]
+        self.assertThat(config_files, AllMatch(
+            hasConfiguration({
+                ("node", "log_gatherer.furl", ""),
+                ("client", "stats_gatherer.furl", ""),
+            })
+        ))
+
+    @given(introducer_configuration(), storage_configuration())
+    @settings(parent=simple)
+    def test_gatherers(self, introducer_config, storage_config):
+        """
+        If the log and stats gatherers are given, the storage and
+        introducer configurations are written with those values for
+        those fields.
+        """
+        introducer_config["root"] = self.nodes.introducer.path
+        storage_config["root"] = self.nodes.storage.path
+
+        # They should match anyway and this makes the assertion below
+        # easier.  Also, one is just as randomly generated as the
+        # other...
+        introducer_config["log_gatherer_furl"] = storage_config["log_gatherer_furl"]
+        introducer_config["stats_gatherer_furl"] = storage_config["stats_gatherer_furl"]
+
+        config = dict(introducer=introducer_config, storage=storage_config)
+        configure_tahoe(config)
+
+        config_files = [
+            self.nodes.introducer.child(b"tahoe.cfg"),
+            self.nodes.storage.child(b"tahoe.cfg"),
+        ]
+        self.assertThat(
+            config_files, AllMatch(
+            hasConfiguration({
+                ("node", "log_gatherer.furl", introducer_config["log_gatherer_furl"]),
+                ("client", "stats_gatherer.furl", introducer_config["stats_gatherer_furl"]),
+            })
+        ))

--- a/lae_automation/test/test_server.py
+++ b/lae_automation/test/test_server.py
@@ -1,18 +1,20 @@
 
 import mock
-from hypothesis import strategies, given, settings
+from hypothesis import given, settings
 
 from json import loads, dumps
-from string import uppercase, lowercase, letters, digits
 from cStringIO import StringIO
 from twisted.trial.unittest import TestCase, SynchronousTestCase
 from twisted.python.filepath import FilePath
 
 from datetime import datetime
 
-from lae_automation import server, signup
+from lae_automation import server
 from lae_automation.server import api
 
+from .strategies import (
+    nickname, bucket_name, ipv4_address, aws_access_key_id, aws_secret_key,
+)
 
 INTRODUCER_PORT = '12345'
 SERVER_PORT = '12346'
@@ -207,54 +209,6 @@ class TestServerModule(TestCase):
             server.create_account(acct_name, pubkey, STDOUT, STDERR)
         self._check_all_done()
 
-
-_BASE32_CHARS = lowercase + "234567"
-
-def nickname():
-    return strategies.text(
-        alphabet=_BASE32_CHARS, min_size=24, max_size=24
-    )
-
-def subscription_id():
-    return strategies.binary(min_size=10, max_size=10).map(
-        lambda b: b'sub_' + b.encode('base64').strip('_')
-    )
-
-def customer_id():
-    return strategies.binary(min_size=10, max_size=10).map(
-        lambda b: b'cus_' + b.encode('base64').strip('_')
-    )
-
-def bucket_name():
-    return strategies.tuples(
-        subscription_id(),
-        customer_id(),
-    ).map(
-        lambda (s, c): signup.get_bucket_name(s, c)
-    )
-
-def ipv4_address():
-    return strategies.lists(
-        elements=strategies.integers(min_value=0, max_value=255),
-        min_size=4, max_size=4,
-    ).map(
-        lambda parts: "{}.{}.{}.{}".format(*parts)
-    )
-
-def aws_access_key_id():
-    return strategies.text(
-        alphabet=uppercase + digits,
-        min_size=20,
-        max_size=20,
-    )
-
-def aws_secret_key():
-    # Maybe it's base64 encoded?
-    return strategies.text(
-        alphabet=letters + digits + "/+",
-        min_size=40,
-        max_size=40,
-    )
 
 class NewTahoeConfigurationTests(SynchronousTestCase):
     """

--- a/lae_automation/test/test_server.py
+++ b/lae_automation/test/test_server.py
@@ -10,10 +10,12 @@ from twisted.python.filepath import FilePath
 from datetime import datetime
 
 from lae_automation import server
+from lae_automation.signup import DeploymentConfiguration
 from lae_automation.server import api
 
 from .strategies import (
     nickname, bucket_name, ipv4_address, aws_access_key_id, aws_secret_key,
+    furl,
 )
 
 INTRODUCER_PORT = '12345'
@@ -218,6 +220,7 @@ class NewTahoeConfigurationTests(SynchronousTestCase):
         nickname(), bucket_name(),
         ipv4_address(), ipv4_address(),
         aws_access_key_id(), aws_secret_key(),
+        furl(), furl(),
     )
     # Limit the number of iterations of this test - generating RSA
     # keys is slow.
@@ -226,15 +229,43 @@ class NewTahoeConfigurationTests(SynchronousTestCase):
             self,
             nickname, bucket_name,
             publichost, privatehost,
-            s3_access_key_id, s3_secret_key
+            s3_access_key_id, s3_secret_key,
+            log_gatherer_furl, stats_gatherer_furl,
     ):
         """
         It returns an object which can be round-tripped through the JSON
         format.
         """
+        deploy_config = DeploymentConfiguration(
+                products=[{}],
+                s3_access_key_id=s3_access_key_id,
+                s3_secret_key=s3_secret_key,
+                bucketname=bucket_name,
+                amiimageid=None,
+                instancesize=None,
+
+                usertoken=None,
+                producttoken=None,
+
+                oldsecrets=None,
+                customer_email=None,
+                customer_pgpinfo=None,
+                secretsfile=FilePath(self.mktemp()).open("w"),
+                serverinfopath=None,
+
+                ssec2_access_key_id=None,
+                ssec2_secret_path=None,
+
+                ssec2admin_keypair_name=None,
+                ssec2admin_privkey_path=None,
+
+                monitor_pubkey_path=None,
+                monitor_privkey_path=None,
+
+                log_gatherer_furl=log_gatherer_furl,
+                stats_gatherer_furl=stats_gatherer_furl,
+            )
         config = server.new_tahoe_configuration(
-            nickname, bucket_name,
-            publichost, privatehost,
-            s3_access_key_id, s3_secret_key,
+            deploy_config, publichost, privatehost,
         )
         self.assertEqual(config, loads(dumps(config)))

--- a/lae_automation/test/test_signup.py
+++ b/lae_automation/test/test_signup.py
@@ -1,5 +1,4 @@
 
-import json
 from base64 import b32encode
 
 import attr

--- a/lae_automation/test/test_signup.py
+++ b/lae_automation/test/test_signup.py
@@ -217,20 +217,19 @@ class TestSignupModule(TestCase):
                 raise NotListeningError()
         self.patch(signup, 'install_server', call_install_server)
 
-        def call_bounce_server(publichost, admin_privkey_path, privatehost, s3_access_key_id,
-                               s3_secretkey, user_token, product_token, bucket_name, oldsecrets,
-                               stdout, stderr, secretsfile):
+        def call_bounce_server(deploy_config, publichost, admin_privkey_path, privatehost,
+                               stdout, stderr):
             self.failUnlessEqual(publichost, '0.0.0.0')
             self.failUnlessEqual(admin_privkey_path, 'ADMINKEYS.pem')
             self.failUnlessEqual(privatehost, '0.0.0.1')
-            self.failUnlessEqual(s3_access_key_id, 'TEST'+'S3'*8)
-            self.failUnlessEqual(s3_secretkey, 'S3'*20)
-            self.failUnlessEqual(bucket_name, "lae-" + self.MENCODED_IDS)
-            self.failUnlessEqual(oldsecrets, None)
+            self.failUnlessEqual(deploy_config.s3_access_key_id, 'TEST'+'S3'*8)
+            self.failUnlessEqual(deploy_config.s3_secret_key, 'S3'*20)
+            self.failUnlessEqual(deploy_config.bucketname, "lae-" + self.MENCODED_IDS)
+            self.failUnlessEqual(deploy_config.oldsecrets, None)
             expected_suffix = 'secrets/XX_consumer_iteration_#_GREEKLETTER#_2XXX-XX-XX/1970-01-01T000000Z-%s/SSEC2' % (self.MENCODED_IDS,)
             self.assertTrue(
-                secretsfile.name.endswith(expected_suffix),
-                secretsfile.name)
+                deploy_config.secretsfile.name.endswith(expected_suffix),
+                deploy_config.secretsfile.name)
         self.patch(signup, 'bounce_server', call_bounce_server)
 
         def call_send_signup_confirmation(publichost, customer_email, furl, customer_keyinfo, stdout,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,11 +13,14 @@ pyOpenSSL
 simplejson
 twisted
 service_identity
+attrs==16.3.0
 
 txAWS==0.2.1.post5
 
 # For the test suite.
 hypothesis==3.6.0
+testtools==2.2.0
+fixtures=3.0.0
 
 # So we can generate tahoe configuration parameters.
 tahoe-lafs==1.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ txAWS==0.2.1.post5
 # For the test suite.
 hypothesis==3.6.0
 testtools==2.2.0
-fixtures=3.0.0
+fixtures==3.0.0
 
 # So we can generate tahoe configuration parameters.
 tahoe-lafs==1.11.0


### PR DESCRIPTION
Fixes #446 

This will pull furls from the cluster configuration (managed separately) and dump them in the right place in the tahoe.cfg files (including creating one for the introducer so it can log as well).
