### PR TITLE
Suppress warnings from debconf during image build

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -25,6 +25,7 @@ ENV SECURITY_UPDATES="2016-10-28"
 # Set a build-only environment variable to suppress warnings from apt
 # and other package management tools caused by the lack of a tty.
 # This can be overridden by --build-arg but that's not the point.
+# See https://github.com/docker/docker/issues/4032
 ARG DEBIAN_FRONTEND=noninteractive
 
 # We'll do an upgrade because the base Ubuntu image isn't guaranteed

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -22,6 +22,11 @@ FROM library/ubuntu:14.04.5
 # being retrieved.
 ENV SECURITY_UPDATES="2016-10-28"
 
+# Set a build-only environment variable to suppress warnings from apt
+# and other package management tools caused by the lack of a tty.
+# This can be overridden by --build-arg but that's not the point.
+ARG DEBIAN_FRONTEND=noninteractive
+
 # We'll do an upgrade because the base Ubuntu image isn't guaranteed
 # to include the latest security updates.  This is counter to best
 # practice recommendations but security updates are important.

--- a/docker/Dockerfile.infrastructure
+++ b/docker/Dockerfile.infrastructure
@@ -6,6 +6,10 @@
 
 FROM leastauthority/base
 
+# This was already set in leastauthority/base but ARG does not cross
+# Dockerfiles.  See Dockerfile.base for explanation.
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Select a postfix configuration so that postfix can be installed
 # without prompting.  And install postfix.
 #


### PR DESCRIPTION
Fixes #387 

Note the issue was about the EC2 setup process.  This doesn't actually fix that.  However, the EC2 setup process will soon be replaced with containers.