### PR TITLE
Retry logic for user S3 bucket creation

### DIFF
--- a/lae_automation/initialize.py
+++ b/lae_automation/initialize.py
@@ -187,6 +187,20 @@ def verify_and_store_serverssh_pubkey(ec2accesskeyid, ec2secretkey, endpoint_uri
 
 
 def create_user_bucket(reactor, client, bucketname):
+    """
+    Create an S3 bucket for a user's grid.
+
+    If S3 errors are encountered, retries will be attempted.  If too
+    many errors are encountered, this will give up and return a
+    failure.
+
+    @param reactor: An IReactorTime which can be used to schedule retries.
+    @param client: A txaws.s3.client.S3Client which can be used to create the bucket.
+    @param bucketname: The name of the S3 bucket to create.
+
+    @return: A Deferred that fires when the bucket has been created or
+        fails when too many errors are encountered.
+    """
     action = startAction(
         action_type=u"initialize:create_user_bucket",
         name=bucketname,

--- a/lae_automation/initialize.py
+++ b/lae_automation/initialize.py
@@ -1,20 +1,28 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
 import subprocess, os, urllib
 
 from twisted.internet import reactor, task, defer
 from twisted.python.filepath import FilePath
 from twisted.conch.client.knownhosts import KnownHostsFile
 
+from eliot import startAction
+from eliot.twisted import DeferredContext
+
+from lae_util import retry_failure, backoff
+
 from lae_automation.aws.license_service_client import LicenseServiceClient
-from txaws.s3.client import S3Client, URLContext
 from lae_automation.aws.devpay_s3client import DevPayS3Client
 from lae_automation.aws.queryapi import xml_parse, xml_find, wait_for_EC2_sshfp, TimeoutError, \
      wait_for_EC2_addresses
 
+from txaws.s3.exception import S3Error
+from txaws.s3.client import S3Client, URLContext
 from txaws.ec2.client import EC2Client
 from txaws.ec2.model import Instance
-from txaws.service import AWSServiceEndpoint
+from txaws.service import AWSServiceEndpoint, AWSServiceRegion
 from txaws.credentials import AWSCredentials
-
 
 class PublicKeyMismatch(Exception):
     pass
@@ -177,12 +185,30 @@ def verify_and_store_serverssh_pubkey(ec2accesskeyid, ec2secretkey, endpoint_uri
     d.addCallback(_got_fingerprintfromconsole)
     return d
 
-def create_stripe_user_bucket(accesskeyid, secretkey, bucketname, stdout, stderr, location):
-    if location is None:
-        print >>stdout, "Creating S3 bucket in 'US East' region..."
-    else:
-        # TODO: print user-friendly region name
-        print >>stdout, "Creating S3 bucket..."
+
+def create_user_bucket(reactor, client, bucketname):
+    action = startAction(
+        action_type=u"initialize:create_user_bucket",
+        name=bucketname,
+    )
+    with action.context():
+        d = DeferredContext(
+            retry_failure(
+                reactor,
+                lambda: client.create_bucket(bucketname),
+                expected=[S3Error],
+                steps=backoff(),
+            ),
+        )
+        d.addActionFinish()
+        return d.result
+
+
+def create_stripe_user_bucket(accesskeyid, secretkey, bucketname, stdout, stderr, location, reactor=None):
+    if reactor is None:
+        from twisted.internet import reactor
+
+    assert location is None, "Alternate S3 bucket locations unimplemented."
 
     print >>stderr, ('usertoken = %r\n'
                      'bucketname = %r\n'
@@ -191,22 +217,11 @@ def create_stripe_user_bucket(accesskeyid, secretkey, bucketname, stdout, stderr
                      'secretkey = %r\n'
                      % (None, bucketname, location, accesskeyid, secretkey))
 
-    LAcreds = AWSCredentials(accesskeyid, secretkey)
-    client = S3Client(creds=LAcreds)
+    region = AWSServiceRegion(creds=AWSCredentials(accesskeyid, secretkey))
+    client = region.get_s3_client()
     print >>stderr, "client is %s" % (client,)
 
-    if location:
-        object_name = "?LocationConstraint=" + urllib.quote(location)
-    else:
-        object_name = None
-
-    query = client.query_factory(
-        action="PUT", creds=client.creds, endpoint=client.endpoint,
-        bucket=bucketname, object_name=object_name)
-    print >>stderr, "query is %s" % (query,)
-    print >>stderr, "%r %r %r" % (query.action, query.data, query.get_headers())
-    print >>stdout, "URL: %r" % (URLContext(query.endpoint, query.bucket, query.object_name).get_url(),)
-    d = query.submit()
+    d  = create_user_bucket(reactor, client, bucketname)
 
     def bucket_created(res):
         print >>stdout, "S3 bucket created."

--- a/lae_automation/test/s3.py
+++ b/lae_automation/test/s3.py
@@ -1,0 +1,58 @@
+from twisted.internet.defer import succeed, fail
+
+from txaws.s3.model import Bucket, BucketListing
+from txaws.s3.exception import S3Error
+
+def rate_limited(f):
+    def g(self, *a, **kw):
+        if get_rate_limit_exceeded(self):
+            return fail(S3Error("<slowdown/>", 400))
+        return f(self, *a, **kw)
+    return g
+
+
+class MemoryS3Client(object):
+    from time import time
+
+    def __init__(self, creds, endpoint):
+        self.creds = creds
+        self.endpoint = endpoint
+        self.buckets = {}
+
+    @rate_limited
+    def list_buckets(self):
+        return succeed(self.buckets.keys())
+
+    @rate_limited
+    def create_bucket(self, bucket):
+        assert bucket not in self.buckets
+        self.buckets[bucket] = dict(
+            bucket=Bucket(bucket, self.time()),
+            listing=BucketListing(bucket, None, None, None, False),
+        )
+        return succeed(None)
+
+    @rate_limited
+    def delete_bucket(self, bucket):
+        if self.buckets[bucket]["listing"].contents:
+            return fail(S3Error("<notempty/>", 400))
+        del self.buckets[bucket]
+        return succeed(None)
+
+    @rate_limited
+    def get_bucket(self, bucket):
+        try:
+            pieces = self.buckets[bucket]
+        except KeyEror:
+            return fail(S3Error("<nosuchbucket/>", 400))
+        return pieces["listing"]
+
+
+def set_rate_limit_exceeded(client):
+    client._rate_limit_exceeded = True
+
+def clear_rate_limit_exceeded(client):
+    client._rate_limit_exceeded = False
+
+def get_rate_limit_exceeded(client):
+    return getattr(client, "_rate_limit_exceeded", False)

--- a/lae_util/__init__.py
+++ b/lae_util/__init__.py
@@ -4,7 +4,8 @@
 __all__ = [
     "with_retry", "retry_if",
     "loop_until", "poll_until",
-    "retry_failure", "timeout",
+    "retry_failure", "backoff",
+    "timeout",
     "get_default_retry_steps",
     "decorate_methods",
 ]
@@ -36,7 +37,8 @@ del _redirect_eliot_logs_for_trial
 from ._retry import (
     with_retry, retry_if,
     loop_until, poll_until,
-    retry_failure, timeout,
+    retry_failure, backoff,
+    timeout,
     get_default_retry_steps,
     decorate_methods,
 )

--- a/lae_util/__init__.py
+++ b/lae_util/__init__.py
@@ -6,3 +6,11 @@ import stripe
 #
 # This overrides the Stripe account-wide API version setting.
 stripe.api_version = '2016-07-06'
+
+from ._retry import (
+    with_retry, retry_if,
+    loop_until, poll_until,
+    retry_failure, timeout,
+    get_default_retry_steps,
+    decorate_methods,
+)

--- a/lae_util/__init__.py
+++ b/lae_util/__init__.py
@@ -1,3 +1,13 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
+__all__ = [
+    "with_retry", "retry_if",
+    "loop_until", "poll_until",
+    "retry_failure", "timeout",
+    "get_default_retry_steps",
+    "decorate_methods",
+]
 
 import stripe
 # Pin the Stripe API version to a known value.  This will need to be

--- a/lae_util/__init__.py
+++ b/lae_util/__init__.py
@@ -17,6 +17,22 @@ import stripe
 # This overrides the Stripe account-wide API version setting.
 stripe.api_version = '2016-07-06'
 
+def _redirect_eliot_logs_for_trial():
+    """
+    Enable Eliot logging to the ``_trial/test.log`` file.
+
+    This wrapper function allows lae_util/__version__.py to be
+    imported by packaging tools without them having to install Eliot
+    and its dependencies.
+    """
+    import os
+    import sys
+    if os.path.basename(sys.argv[0]) == "trial":
+        from eliot.twisted import redirectLogsForTrial
+        redirectLogsForTrial()
+_redirect_eliot_logs_for_trial()
+del _redirect_eliot_logs_for_trial
+
 from ._retry import (
     with_retry, retry_if,
     loop_until, poll_until,

--- a/lae_util/_retry.py
+++ b/lae_util/_retry.py
@@ -1,0 +1,540 @@
+# Copyright 2014-2016 ClusterHQ
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Helpers for retrying things.
+
+Originally ``flocker/common/_retry.py``.
+"""
+
+from __future__ import absolute_import, division
+
+from sys import exc_info
+
+from datetime import timedelta
+from functools import partial
+from inspect import getfile, getsourcelines
+from itertools import chain, count, imap, repeat, takewhile
+from random import uniform
+import time
+
+from eliot import (
+    ActionType, MessageType, Message, Field, start_action,
+)
+from eliot.twisted import DeferredContext
+
+from twisted.python.reflect import fullyQualifiedName, safe_repr
+from twisted.python.failure import Failure
+from twisted.internet.task import deferLater
+from twisted.internet.defer import maybeDeferred
+
+from effect import Effect, Constant, Delay
+from effect.retry import retry
+
+
+def backoff(step=5.0, maximum_step=60.0, timeout=10*60.0, jitter=0.2):
+    """
+    Generate increasingly large values for use as the ``steps`` argument to
+    retry functions.
+
+    :param float step: The amount by which to increase successive values.
+    :param float maximum_step: The maximum value that will be
+        generated. ``None`` means no maximum.
+    :param float timeout: No further values will be generated when the sum of
+        the generated steps is greater than ``timeout``. ``None`` means no
+        timeout.
+    :param float jitter: If not ``None``, the generated values will be adjusted
+        by a random amount between +/- ``jitter.
+    :returns: A generator of floats.
+    """
+    if step <= 0.0:
+        raise ValueError("Invalid ``step`` ({!r}). "
+                         "Must be > 0.0.".format(step))
+    steps = imap(
+        lambda x: x * step,
+        count(start=1)
+    )
+    if maximum_step is not None:
+        if maximum_step <= 0.0:
+            raise ValueError(
+                "Invalid ``maximum_step`` ({!r}). "
+                "Must be > 0.0.".format(
+                    maximum_step
+                )
+            )
+
+        steps = takewhile(
+            lambda x: x < maximum_step,
+            steps
+        )
+        steps = chain(
+            steps,
+            repeat(maximum_step)
+        )
+    if jitter is not None:
+        steps = imap(
+            lambda x: x + uniform(-jitter, jitter),
+            steps,
+        )
+    if timeout is not None:
+        total_time = [0]
+
+        def maybe_timeout(values):
+            for value in values:
+                total_time[0] += value
+                if total_time[0] > timeout:
+                    break
+                yield value
+
+        steps = maybe_timeout(steps)
+
+    return steps
+
+
+def function_serializer(function):
+    """
+    Serialize the given function for logging by eliot.
+
+    :param function: Function to serialize.
+
+    :return: Serialized version of function for inclusion in logs.
+    """
+    try:
+        return {
+            "function": str(function),
+            "file": getfile(function),
+            "line": getsourcelines(function)[1]
+        }
+    except IOError:
+        # One debugging method involves changing .py files and is incompatible
+        # with inspecting the source.
+        return {
+            "function": str(function),
+        }
+    except TypeError:
+        # Callable not supported by inspect.getfile
+        if isinstance(function, partial):
+            return {
+                'partial': function_serializer(function.func)
+            }
+        else:
+            return {
+                "function": str(function),
+            }
+
+
+class LoopExceeded(Exception):
+    """
+    Raised when ``loop_until`` looped too many times.
+    """
+
+    def __init__(self, predicate, last_result):
+        super(LoopExceeded, self).__init__(
+            '%r never True in loop_until, last result: %r'
+            % (predicate, last_result))
+
+
+LOOP_UNTIL_ACTION = ActionType(
+    action_type="flocker:common:loop_until",
+    startFields=[Field("predicate", function_serializer)],
+    successFields=[Field("result", serializer=safe_repr)],
+    description="Looping until predicate is true.")
+
+LOOP_UNTIL_ITERATION_MESSAGE = MessageType(
+    message_type="flocker:common:loop_until:iteration",
+    fields=[Field("result", serializer=safe_repr)],
+    description="Predicate failed, trying again.")
+
+
+def loop_until(reactor, predicate, steps=None):
+    """Repeatedly call ``predicate``, until it returns something ``Truthy``.
+
+    :param reactor: The reactor implementation to use to delay.
+    :type reactor: ``IReactorTime``.
+
+    :param predicate: Callable returning termination condition.
+    :type predicate: 0-argument callable returning a Deferred.
+
+    :param steps: An iterable of delay intervals, measured in seconds.
+        If not provided, will default to retrying every 0.1 seconds forever.
+
+    :raise LoopExceeded: If given a finite sequence of steps, and we exhaust
+        that sequence waiting for predicate to be truthy.
+
+    :return: A ``Deferred`` firing with the first ``Truthy`` response from
+        ``predicate``.
+    """
+    if steps is None:
+        steps = repeat(0.1)
+    steps = iter(steps)
+
+    action = LOOP_UNTIL_ACTION(predicate=predicate)
+
+    d = action.run(DeferredContext, maybeDeferred(action.run, predicate))
+
+    def loop(result):
+        if not result:
+            LOOP_UNTIL_ITERATION_MESSAGE(
+                result=result
+            ).write()
+            try:
+                delay = steps.next()
+            except StopIteration:
+                raise LoopExceeded(predicate, result)
+            d = deferLater(reactor, delay, action.run, predicate)
+            d.addCallback(partial(action.run, loop))
+            return d
+        action.addSuccessFields(result=result)
+        return result
+    d.addCallback(loop)
+    return d.addActionFinish()
+
+
+def timeout(reactor, deferred, timeout_sec, reason=None):
+    """
+    Adds a timeout to an existing deferred.  If the timeout expires before the
+    deferred expires, then the deferred is cancelled.
+
+    :param IReactorTime reactor: The reactor implementation to schedule the
+        timeout.
+    :param Deferred deferred: The deferred to cancel at a later point in time.
+    :param float timeout_sec: The number of seconds to wait before the deferred
+        should time out.
+    :param Exception reason: An exception used to create a Failure with which
+        to fire the Deferred if the timeout is encountered.  If not given,
+        ``deferred`` retains its original failure behavior.
+
+    :return: The updated deferred.
+    """
+    def _timeout():
+        deferred.cancel()
+
+    delayed_timeout = reactor.callLater(timeout_sec, _timeout)
+
+    if reason is not None:
+        def maybe_replace_reason(passthrough):
+            if delayed_timeout.active():
+                return passthrough
+            return Failure(reason)
+        deferred.addErrback(maybe_replace_reason)
+
+    def abort_timeout(passthrough):
+        if delayed_timeout.active():
+            delayed_timeout.cancel()
+        return passthrough
+    deferred.addBoth(abort_timeout)
+
+    return deferred
+
+
+def retry_failure(reactor, function, expected=None, steps=None):
+    """
+    Retry ``function`` until it returns successfully.
+
+    If it raises one of the expected exceptions, then retry.
+
+    :param IReactorTime reactor: The reactor implementation to use to delay.
+    :param callable function: A callable that returns a value.
+    :param expected: Iterable of exceptions that trigger a retry. Passed
+        through to ``Failure.check``.
+    :param [float] steps: An iterable of delay intervals, measured in seconds.
+        If not provided, will default to retrying every 0.1 seconds.
+
+    :return: A ``Deferred`` that fires with the first successful return value
+        of ``function``.
+    """
+    if steps is None:
+        steps = repeat(0.1)
+    steps = iter(steps)
+
+    action = LOOP_UNTIL_ACTION(predicate=function)
+    with action.context():
+        d = DeferredContext(maybeDeferred(function))
+
+    def loop(failure):
+        if expected and not failure.check(*expected):
+            return failure
+
+        try:
+            interval = steps.next()
+        except StopIteration:
+            return failure
+
+        d = deferLater(reactor, interval, action.run, function)
+        d.addErrback(loop)
+        return d
+
+    d.addErrback(loop)
+
+    def got_result(result):
+        action.add_success_fields(result=result)
+        return result
+    d.addCallback(got_result)
+    d.addActionFinish()
+    return d.result
+
+
+def poll_until(predicate, steps, sleep=None):
+    """
+    Perform steps until a non-false result is returned.
+
+    This differs from ``loop_until`` in that it does not require a
+    Twisted reactor.
+
+    :param predicate: a function to be called until it returns a
+        non-false result.
+    :param [float] steps: An iterable of delay intervals, measured in seconds.
+    :param callable sleep: called with the interval to delay on.
+        Defaults to `time.sleep`.
+    :returns: the non-false result from the final call.
+    :raise LoopExceeded: If given a finite sequence of steps, and we exhaust
+        that sequence waiting for predicate to be truthy.
+    """
+    if sleep is None:
+        sleep = time.sleep
+    for step in steps:
+        result = predicate()
+        if result:
+            return result
+        sleep(step)
+    result = predicate()
+    if result:
+        return result
+    raise LoopExceeded(predicate, result)
+
+
+# TODO: Would be nice if this interface were more similar to some of the other
+# retry functions in this module.  For example, accept an iterable of intervals
+# instead of timeout/retry_wait/backoff.
+def retry_effect_with_timeout(effect, timeout, retry_wait=timedelta(seconds=1),
+                              backoff=True, time=time.time):
+    """
+    If ``effect`` fails, retry it until ``timeout`` expires.
+
+    To avoid excessive retrying, this function uses the exponential backoff
+    algorithm by default, waiting double the time between each retry.
+
+    :param Effect effect: The Effect to retry.
+    :param int timeout: Keep retrying until timeout.  This is measured in
+        seconds from the time of the first failure of ``effect``.
+    :param timedelta retry_wait: The wait time between retries
+    :param bool backoff: Whether we should use exponential backoff
+    :param callable time: A nullary callable that returns a UNIX timestamp.
+
+    :return: An Effect that does what ``effect`` does, but retrying on
+        exception.
+    """
+    class State(object):
+        end_time = None
+        wait_time = None
+
+    def should_retry(exc_info):
+        # This is the wrong time to compute end_time.  It's a lot simpler to do
+        # this than to hook into the effect being wrapped and record the time
+        # it starts to run.  Perhaps implementing that would be a nice thing to
+        # do later.
+        #
+        # Anyway, make note of when we want to be finished if we haven't yet
+        # done so.
+        if State.end_time is None:
+            State.end_time = time() + timeout
+
+        if time() >= State.end_time:
+            return Effect(Constant(False))
+        else:
+            retry_delay = State.wait_time.total_seconds()
+            effect = Effect(Delay(retry_delay)).on(
+                success=lambda x: Effect(Constant(True))
+            )
+
+            if backoff:
+                State.wait_time *= 2
+
+            return effect
+
+    State.wait_time = retry_wait
+
+    return retry(effect, should_retry)
+
+
+_TRY_UNTIL_SUCCESS = u"flocker:failure-retry"
+_TRY_RETRYING = _TRY_UNTIL_SUCCESS + u":retrying"
+_TRY_FAILURE = _TRY_UNTIL_SUCCESS + u":failure"
+_TRY_SUCCESS = _TRY_UNTIL_SUCCESS + u":success"
+
+
+def get_default_retry_steps(
+    delay=timedelta(seconds=0.1),
+    max_time=timedelta(minutes=2)
+):
+    """
+    Retry every 0.1 seconds for 2 minutes.
+    """
+    repetitions = max_time.total_seconds() / delay.total_seconds()
+    return repeat(delay, int(repetitions))
+
+
+def retry_always(exc_type, value, traceback):
+    pass
+
+
+def retry_if(predicate):
+    """
+    Create a predicate compatible with ``with_retry``
+    which will retry if the raised exception satisfies the given predicate.
+
+    :param predicate: A one-argument callable which will be called with the
+        raised exception instance only.  It should return ``True`` if a retry
+        should be attempted, ``False`` otherwise.
+    """
+    def should_retry(exc_type, value, traceback):
+        if predicate(value):
+            return None
+        raise exc_type, value, traceback
+    return should_retry
+
+
+# TODO Move this helper to somewhere else in flocker.common.  It's not
+# particular to any retry logic.
+def decorate_methods(obj, decorator):
+    """
+    Return a wrapper around ``obj`` with ``decorator`` applied to all of its
+    method calls.
+
+    For example, to retry on IOError up to 5 times with a 3 second delay
+    between each try::
+
+        retry_three_times = partial(
+            with_retry,
+            should_retry=retry_if(lambda exc: isinstance(exc, IOError)),
+            steps=[timedelta(seconds=3)] * 5,
+        )
+        obj_with_three_retries = decorate_methods(obj, retry_three_times)
+
+    :param callable decorator: A unary callable that takes a method and returns
+        a method.
+
+    :return: An object like ``obj`` but with all the methods decorated.
+    """
+    return _DecoratedInstance(obj, decorator)
+
+
+def _poll_until_success_returning_result(
+    should_retry, steps, sleep, function, args, kwargs
+):
+    """
+    Call a function until it does not raise an exception or ``should_retry``
+    says it shouldn't be tried anymore, whichever comes first.
+
+    :param should_retry: See ``should_retry`` parameter of ``with_retry``.
+    :param steps: See ``steps`` parameter of ``with_retry``.
+    :param sleep: See ``sleep`` parameter of ``with_retry``.
+    :param function: The function to try calling.
+    :param args: Position arguments to pass to the function.
+    :param kwargs: Keyword arguments to pass to the function.
+
+    :return: The value returned by ``function`` on the first call where it
+        returns a value instead of raising an exception.
+    """
+    saved_result = [None]
+
+    def pollable():
+        Message.new(
+            message_type=_TRY_RETRYING,
+        ).write()
+        try:
+            result = function(*args, **kwargs)
+        except Exception as e:
+            saved_result[0] = exc_info()
+            should_retry(*saved_result[0])
+            Message.new(
+                message_type=_TRY_FAILURE,
+                exception=str(e),
+            ).write()
+            return False
+        else:
+            Message.new(
+                message_type=_TRY_SUCCESS,
+                result=result,
+            ).write()
+            saved_result[0] = result
+            return True
+
+    try:
+        poll_until(
+            pollable, (step.total_seconds() for step in steps), sleep=sleep,
+        )
+    except LoopExceeded:
+        # XXX untested
+        thing = saved_result.pop()
+        try:
+            raise thing[0], thing[1], thing[2]
+        finally:
+            del thing
+    else:
+        return saved_result[0]
+
+
+def with_retry(method, should_retry=None, steps=None, sleep=None):
+    """
+    Return a new version of ``method`` that retries.
+
+    :param callable method: A method to retry.
+    :param callable should_retry: A one-argument callable which accepts a
+        three-tuple of exception state and returns ``None`` or raises an
+        exception.  If ``None`` is returned, the call will be retried after a
+        delay given by the next element of ``steps``.  If an exception is
+        raised, no further retries are attempted and the exception is
+        propagated from the method call.
+    :param steps: An iterator of delay intervals (as ``timedelta`` instances).
+        These intervals give the amount of time to wait between retries.
+    :param callable sleep: A replacement for ``time.sleep``.
+
+    :return: A method that will retry.
+    """
+    if should_retry is None:
+        should_retry = retry_always
+
+    if steps is None:
+        steps = get_default_retry_steps()
+
+    def method_with_retry(*a, **kw):
+        name = _callable_repr(method)
+        action_type = _TRY_UNTIL_SUCCESS
+        with start_action(action_type=action_type, function=name):
+            return _poll_until_success_returning_result(
+                should_retry, steps, sleep, method, a, kw
+            )
+    return method_with_retry
+
+
+def _callable_repr(method):
+    """Get a useful representation ``method``."""
+    try:
+        return fullyQualifiedName(method)
+    except AttributeError:
+        return safe_repr(method)
+
+
+class _DecoratedInstance(object):
+    def __init__(self, wrapped, decorator, **kw):
+        self._wrapped = wrapped
+        self._decorator = decorator
+        self._kw = kw
+
+    def __getattr__(self, name):
+        attribute = getattr(self._wrapped, name)
+        if callable(attribute):
+            return self._decorator(attribute, **self._kw)
+        return attribute

--- a/lae_util/test/test_retry.py
+++ b/lae_util/test/test_retry.py
@@ -41,17 +41,10 @@ from twisted.internet.defer import CancelledError
 from twisted.internet.task import Clock
 from twisted.python.failure import Failure
 
-from effect import (
-    Effect,
-    Func,
-    Constant,
-    Delay,
-)
-from effect.testing import perform_sequence
+from lae_util.testtools import TestCase
 
 from .. import (
     loop_until,
-    retry_effect_with_timeout,
     retry_failure,
     poll_until,
     timeout,
@@ -66,7 +59,10 @@ from .._retry import (
     LOOP_UNTIL_ITERATION_MESSAGE,
     LoopExceeded,
 )
-from ...testtools import TestCase, CustomException
+
+
+class CustomException(Exception):
+    pass
 
 
 class LoopUntilTests(TestCase):
@@ -591,165 +587,6 @@ class PollUntilTests(TestCase):
         self.assertEqual(
             42,
             poll_until(lambda: results.pop(0), steps, lambda ignored: None))
-
-
-class RetryEffectTests(TestCase):
-    """
-    Tests for :py:func:`retry_effect_with_timeout`.
-    """
-    def get_time(self, times=None):
-        if times is None:
-            times = [1.0, 2.0, 3.0, 4.0, 5.0]
-
-        def fake_time():
-            return times.pop(0)
-        return fake_time
-
-    def test_immediate_success(self):
-        """
-        If the wrapped effect succeeds at first, no delay or retry is done and
-        the retry effect's result is the wrapped effect's result.
-        """
-        effect = Effect(Constant(1000))
-        retrier = retry_effect_with_timeout(effect, 10, time=self.get_time())
-        result = perform_sequence([], retrier)
-        self.assertEqual(result, 1000)
-
-    def test_one_retry(self):
-        """
-        Retry the effect if it fails once.
-        """
-        divisors = [0, 1]
-
-        def tester():
-            x = divisors.pop(0)
-            return 1 / x
-
-        seq = [
-            (Delay(1), lambda ignore: None),
-        ]
-
-        retrier = retry_effect_with_timeout(Effect(Func(tester)), 10,
-                                            time=self.get_time())
-        result = perform_sequence(seq, retrier)
-        self.assertEqual(result, 1 / 1)
-
-    def test_exponential_backoff(self):
-        """
-        Retry the effect multiple times with exponential backoff between
-        retries.
-        """
-        divisors = [0, 0, 0, 1]
-
-        def tester():
-            x = divisors.pop(0)
-            return 1 / x
-
-        seq = [
-            (Delay(1), lambda ignore: None),
-            (Delay(2), lambda ignore: None),
-            (Delay(4), lambda ignore: None),
-        ]
-
-        retrier = retry_effect_with_timeout(
-            Effect(Func(tester)), timeout=10, time=self.get_time(),
-        )
-        result = perform_sequence(seq, retrier)
-        self.assertEqual(result, 1)
-
-    def test_no_exponential_backoff(self):
-        """
-        If ``False`` is passed for the ``backoff`` parameter, the effect is
-        always retried with the same delay.
-        """
-        divisors = [0, 0, 0, 1]
-
-        def tester():
-            x = divisors.pop(0)
-            return 1 / x
-
-        seq = [
-            (Delay(5), lambda ignore: None),
-            (Delay(5), lambda ignore: None),
-            (Delay(5), lambda ignore: None),
-        ]
-
-        retrier = retry_effect_with_timeout(
-            Effect(Func(tester)), timeout=1, retry_wait=timedelta(seconds=5),
-            backoff=False,
-        )
-        result = perform_sequence(seq, retrier)
-        self.assertEqual(result, 1)
-
-    def test_timeout(self):
-        """
-        If the timeout expires, the retry effect fails with the exception from
-        the final time the wrapped effect is performed.
-        """
-        expected_intents = [
-            (Delay(1), lambda ignore: None),
-            (Delay(2), lambda ignore: None),
-        ]
-
-        exceptions = [
-            Exception("Wrong (1)"),
-            Exception("Wrong (2)"),
-            CustomException(),
-        ]
-
-        def tester():
-            raise exceptions.pop(0)
-
-        retrier = retry_effect_with_timeout(
-            Effect(Func(tester)),
-            timeout=3,
-            time=self.get_time([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),
-        )
-
-        self.assertRaises(
-            CustomException,
-            perform_sequence, expected_intents, retrier
-        )
-
-    def test_timeout_measured_from_perform(self):
-        """
-        The timeout is measured from the time the effect is performed (not from
-        the time it is created).
-        """
-        timeout = 3.0
-        time = self.get_time([0.0] + list(timeout + i for i in range(10)))
-
-        exceptions = [Exception("One problem")]
-        result = object()
-
-        def tester():
-            if exceptions:
-                raise exceptions.pop()
-            return result
-
-        retrier = retry_effect_with_timeout(
-            Effect(Func(tester)),
-            timeout=3,
-            time=time,
-        )
-
-        # The retry effect has been created.  Advance time a little bit before
-        # performing it.
-        time()
-
-        expected_intents = [
-            # The first call raises an exception and should be retried even
-            # though (as a side-effect of the `time` call above) the timeout,
-            # as measured from when `retry_effect_with_timeout` was called, has
-            # already elapsed.
-            #
-            # There's no second intent because the second call to the function
-            # succeeds.
-            (Delay(1), lambda ignore: None),
-        ]
-        self.assertThat(
-            perform_sequence(expected_intents, retrier), Is(result)
-        )
 
 
 EXPECTED_RETRY_SOME_TIMES_RETRIES = 1200

--- a/lae_util/test/test_retry.py
+++ b/lae_util/test/test_retry.py
@@ -1,0 +1,1111 @@
+# Copyright 2014-2016 ClusterHQ
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for ``lae_util._retry``.
+
+Originally ``flocker/common/test/test_retry.py``.
+"""
+
+from datetime import timedelta
+from itertools import count, islice, repeat, izip
+from functools import partial
+
+from hypothesis import given, assume
+from hypothesis import strategies as st
+
+from testtools.matchers import (
+    MatchesPredicate, Is, Equals, AllMatch, IsInstance, GreaterThan, raises
+)
+
+from eliot import MessageType, fields
+from eliot.testing import (
+    capture_logging,
+    LoggedAction, LoggedMessage,
+    assertContainsFields, assertHasAction,
+)
+
+from twisted.internet.defer import succeed, fail, Deferred
+from twisted.internet.defer import CancelledError
+from twisted.internet.task import Clock
+from twisted.python.failure import Failure
+
+from effect import (
+    Effect,
+    Func,
+    Constant,
+    Delay,
+)
+from effect.testing import perform_sequence
+
+from .. import (
+    loop_until,
+    retry_effect_with_timeout,
+    retry_failure,
+    poll_until,
+    timeout,
+    retry_if,
+    get_default_retry_steps,
+    decorate_methods,
+    with_retry,
+)
+from .._retry import (
+    backoff,
+    LOOP_UNTIL_ACTION,
+    LOOP_UNTIL_ITERATION_MESSAGE,
+    LoopExceeded,
+)
+from ...testtools import TestCase, CustomException
+
+
+class LoopUntilTests(TestCase):
+    """
+    Tests for :py:func:`loop_until`.
+    """
+
+    @capture_logging(None)
+    def test_immediate_success(self, logger):
+        """
+        If the predicate returns something truthy immediately, then
+        ``loop_until`` returns a deferred that has already fired with that
+        value.
+        """
+        result = object()
+
+        def predicate():
+            return result
+        clock = Clock()
+        d = loop_until(clock, predicate)
+        self.assertEqual(
+            self.successResultOf(d),
+            result)
+
+        action = LoggedAction.of_type(logger.messages, LOOP_UNTIL_ACTION)[0]
+        assertContainsFields(self, action.start_message, {
+            'predicate': predicate,
+        })
+        assertContainsFields(self, action.end_message, {
+            'action_status': 'succeeded',
+            'result': result,
+        })
+
+    @capture_logging(None)
+    def test_iterates(self, logger):
+        """
+        If the predicate returns something falsey followed by something truthy,
+        then ``loop_until`` returns it immediately.
+        """
+        result = object()
+        results = [None, result]
+
+        def predicate():
+            return results.pop(0)
+        clock = Clock()
+
+        d = loop_until(clock, predicate)
+
+        self.assertNoResult(d)
+
+        clock.advance(0.1)
+        self.assertEqual(
+            self.successResultOf(d),
+            result)
+
+        action = LoggedAction.of_type(logger.messages, LOOP_UNTIL_ACTION)[0]
+        assertContainsFields(self, action.start_message, {
+            'predicate': predicate,
+        })
+        assertContainsFields(self, action.end_message, {
+            'result': result,
+        })
+        self.assertTrue(action.succeeded)
+        message = LoggedMessage.of_type(
+            logger.messages, LOOP_UNTIL_ITERATION_MESSAGE)[0]
+        self.assertEqual(action.children, [message])
+        assertContainsFields(self, message.message, {
+            'result': None,
+        })
+
+    @capture_logging(None)
+    def test_multiple_iterations(self, logger):
+        """
+        If the predicate returns something falsey followed by something truthy,
+        then ``loop_until`` returns it immediately.
+        """
+        result = object()
+        results = [None, False, result]
+        expected_results = results[:-1]
+
+        def predicate():
+            return results.pop(0)
+        clock = Clock()
+
+        d = loop_until(clock, predicate)
+
+        clock.advance(0.1)
+        self.assertNoResult(d)
+        clock.advance(0.1)
+
+        self.assertEqual(
+            self.successResultOf(d),
+            result)
+
+        action = LoggedAction.of_type(logger.messages, LOOP_UNTIL_ACTION)[0]
+        assertContainsFields(self, action.start_message, {
+            'predicate': predicate,
+        })
+        assertContainsFields(self, action.end_message, {
+            'result': result,
+        })
+        self.assertTrue(action.succeeded)
+        messages = LoggedMessage.of_type(
+            logger.messages, LOOP_UNTIL_ITERATION_MESSAGE)
+        self.assertEqual(action.children, messages)
+        self.assertEqual(
+            [messages[0].message['result'], messages[1].message['result']],
+            expected_results,
+        )
+
+    @capture_logging(None)
+    def test_custom_time_steps(self, logger):
+        """
+        loop_until can be passed a generator of intervals to wait on.
+        """
+        result = object()
+        results = [None, False, result]
+
+        def predicate():
+            return results.pop(0)
+        clock = Clock()
+
+        d = loop_until(clock, predicate, steps=[1, 2, 3])
+
+        clock.advance(1)
+        self.assertNoResult(d)
+        clock.advance(1)
+        self.assertNoResult(d)
+        clock.advance(1)
+
+        self.assertEqual(self.successResultOf(d), result)
+
+    @capture_logging(None)
+    def test_fewer_steps_than_repeats(self, logger):
+        """
+        loop_until can be given fewer steps than it needs for the predicate to
+        return True. In that case, we raise ``LoopExceeded``.
+        """
+        results = [False] * 5
+        steps = [0.1] * 2
+
+        def predicate():
+            return results.pop(0)
+        clock = Clock()
+
+        d = loop_until(clock, predicate, steps=steps)
+
+        clock.advance(0.1)
+        self.assertNoResult(d)
+        clock.advance(0.1)
+        self.assertEqual(
+            str(self.failureResultOf(d).value),
+            str(LoopExceeded(predicate, False)))
+
+    @capture_logging(None)
+    def test_partial_predicate(self, logger):
+        """
+        Predicate can be a functools.partial function.
+        """
+        result = object()
+
+        def check():
+            return result
+        predicate = partial(check)
+
+        clock = Clock()
+        d = loop_until(clock, predicate)
+        self.assertEqual(
+            self.successResultOf(d),
+            result)
+
+        [action] = LoggedAction.of_type(logger.messages, LOOP_UNTIL_ACTION)
+        assertContainsFields(self, action.start_message, {
+            'predicate': predicate,
+        })
+        assertContainsFields(self, action.end_message, {
+            'action_status': 'succeeded',
+            'result': result,
+        })
+
+
+class TimeoutTests(TestCase):
+    """
+    Tests for :py:func:`timeout`.
+    """
+
+    def setUp(self):
+        """
+        Initialize testing helper variables.
+        """
+        super(TimeoutTests, self).setUp()
+        self.deferred = Deferred()
+        self.timeout = 10.0
+        self.clock = Clock()
+
+    def test_doesnt_time_out_early(self):
+        """
+        A deferred that has not fired by some short while prior to the timeout
+        interval is not made to fire with a timeout failure.
+        """
+        deferred = timeout(self.clock, self.deferred, self.timeout)
+        self.clock.advance(self.timeout - 1.0)
+        self.assertNoResult(deferred)
+
+    def test_times_out(self):
+        """
+        A deferred that does not fire within the timeout interval is made to
+        fire with ``CancelledError`` once the timeout interval elapses.
+        """
+        deferred = timeout(self.clock, self.deferred, self.timeout)
+        self.clock.advance(self.timeout)
+        self.failureResultOf(deferred, CancelledError)
+
+    def test_times_out_with_reason(self):
+        """
+        If a custom reason is passed to ``timeout`` and the Deferred does not
+        fire within the timeout interval, it is made to fire with the custom
+        reason once the timeout interval elapses.
+        """
+        reason = CustomException(self.id())
+        deferred = timeout(self.clock, self.deferred, self.timeout, reason)
+        self.clock.advance(self.timeout)
+        self.assertEqual(
+            reason,
+            self.failureResultOf(deferred, CustomException).value,
+        )
+
+    def test_doesnt_time_out(self):
+        """
+        A deferred that fires before the timeout is not cancelled by the
+        timeout.
+        """
+        deferred = timeout(self.clock, self.deferred, self.timeout)
+        self.clock.advance(self.timeout - 1.0)
+        self.deferred.callback('Success')
+        self.assertEqual(self.successResultOf(deferred), 'Success')
+
+    def test_doesnt_time_out_failure(self):
+        """
+        A Deferred that fails before the timeout is not cancelled by the
+        timeout.
+        """
+        deferred = timeout(self.clock, self.deferred, self.timeout)
+        self.clock.advance(self.timeout - 1.0)
+        self.deferred.errback(CustomException(self.id()))
+        self.failureResultOf(deferred, CustomException)
+
+    def test_doesnt_time_out_failure_custom_reason(self):
+        """
+        A Deferred that fails before the timeout is not cancelled by the
+        timeout.
+        """
+        deferred = timeout(
+            self.clock, self.deferred, self.timeout,
+            ValueError("This should not appear.")
+        )
+        self.clock.advance(self.timeout - 1.0)
+        self.deferred.errback(CustomException(self.id()))
+        self.failureResultOf(deferred, CustomException)
+
+    def test_advancing_after_success(self):
+        """
+        A Deferred that fires before the timeout continues to succeed after the
+        timeout has elapsed.
+        """
+        deferred = succeed('Success')
+        timeout(self.clock, deferred, self.timeout)
+        self.clock.advance(self.timeout)
+        self.assertEqual(self.successResultOf(deferred), 'Success')
+
+    def test_advancing_after_failure(self):
+        """
+        A Deferred that fires with a failure before the timeout continues to
+        fail after the timeout has elapsed.
+        """
+        deferred = fail(CustomException(self.id()))
+        timeout(self.clock, deferred, self.timeout)
+        self.clock.advance(self.timeout)
+        self.failureResultOf(deferred, CustomException)
+
+    def test_timeout_cleaned_up_on_success(self):
+        """
+        If the deferred is successfully completed before the timeout, the
+        timeout is not still pending on the reactor.
+        """
+        timeout(self.clock, self.deferred, self.timeout)
+        self.deferred.callback('Success')
+        self.assertEqual(self.clock.getDelayedCalls(), [])
+
+    def test_timeout_cleaned_up_on_failure(self):
+        """
+        If the deferred is failed before the timeout, the timeout is not still
+        pending on the reactor.
+        """
+        timeout(self.clock, self.deferred, self.timeout)
+        self.deferred.errback(CustomException(self.id()))
+        # We need to handle the errback so that Trial and/or testtools don't
+        # fail with unhandled errors.
+        self.addCleanup(self.deferred.addErrback, lambda _: None)
+        self.assertEqual(self.clock.getDelayedCalls(), [])
+
+
+ITERATION_MESSAGE = MessageType("iteration_message", fields(iteration=int))
+
+
+class RetryFailureTests(TestCase):
+    """
+    Tests for :py:func:`retry_failure`.
+    """
+
+    def test_immediate_success(self):
+        """
+        If the function returns a successful value immediately, then
+        ``retry_failure`` returns a deferred that has already fired with that
+        value.
+        """
+        result = object()
+
+        def function():
+            return result
+
+        clock = Clock()
+        d = retry_failure(clock, function)
+        self.assertEqual(self.successResultOf(d), result)
+
+    def test_iterates_once(self):
+        """
+        If the function fails at first and then succeeds, ``retry_failure``
+        returns the success.
+        """
+        steps = [0.1]
+
+        result = object()
+        results = [Failure(ValueError("bad value")), succeed(result)]
+
+        def function():
+            return results.pop(0)
+
+        clock = Clock()
+
+        d = retry_failure(clock, function, steps=steps)
+        self.assertNoResult(d)
+
+        clock.advance(0.1)
+        self.assertEqual(self.successResultOf(d), result)
+
+    def assert_logged_multiple_iterations(self, logger):
+        """
+        Function passed to ``retry_failure`` is run in the context of a
+        ``LOOP_UNTIL_ACTION``.
+        """
+        iterations = LoggedMessage.of_type(logger.messages, ITERATION_MESSAGE)
+        loop = assertHasAction(self, logger, LOOP_UNTIL_ACTION, True)
+        self.assertEqual(
+            sorted(iterations, key=lambda m: m.message["iteration"]),
+            loop.children)
+
+    @capture_logging(assert_logged_multiple_iterations)
+    def test_multiple_iterations(self, logger):
+        """
+        If the function fails multiple times and then succeeds,
+        ``retry_failure`` returns the success.
+        """
+        steps = [0.1, 0.2]
+
+        result = object()
+        results = [
+            Failure(ValueError("bad value")),
+            Failure(ValueError("bad value")),
+            succeed(result),
+        ]
+
+        def function():
+            ITERATION_MESSAGE(iteration=(3 - len(results))).write()
+            return results.pop(0)
+
+        clock = Clock()
+
+        d = retry_failure(clock, function, steps=steps)
+        self.assertNoResult(d)
+
+        clock.advance(0.1)
+        self.assertNoResult(d)
+
+        clock.advance(0.1)
+        self.assertNoResult(d)
+
+        clock.advance(0.1)
+        self.assertEqual(self.successResultOf(d), result)
+
+    def test_too_many_iterations(self):
+        """
+        If ``retry_failure`` fails more times than there are steps provided, it
+        errors back with the last failure.
+        """
+        steps = [0.1]
+
+        result = object()
+        failure = Failure(ValueError("really bad value"))
+
+        results = [
+            Failure(ValueError("bad value")),
+            failure,
+            succeed(result),
+        ]
+
+        def function():
+            return results.pop(0)
+
+        clock = Clock()
+
+        d = retry_failure(clock, function, steps=steps)
+        self.assertNoResult(d)
+
+        clock.advance(0.1)
+        self.assertEqual(self.failureResultOf(d), failure)
+
+    def test_no_steps(self):
+        """
+        Calling ``retry_failure`` with an empty iterator for ``steps`` is the
+        same as wrapping the function in ``maybeDeferred``.
+        """
+        steps = []
+
+        result = object()
+        failure = Failure(ValueError("really bad value"))
+
+        results = [
+            failure,
+            succeed(result),
+        ]
+
+        def function():
+            return results.pop(0)
+
+        clock = Clock()
+
+        d = retry_failure(clock, function, steps=steps)
+        self.assertEqual(self.failureResultOf(d), failure)
+
+    def test_limited_exceptions(self):
+        """
+        By default, ``retry_failure`` retries on any exception. However, if
+        it's given an iterable of expected exception types (exactly as one
+        might pass to ``Failure.check``), then it will only retry if one of
+        *those* exceptions is raised.
+        """
+        steps = [0.1, 0.2]
+
+        result = object()
+        type_error = Failure(TypeError("bad type"))
+
+        results = [
+            Failure(ValueError("bad value")),
+            type_error,
+            succeed(result),
+        ]
+
+        def function():
+            return results.pop(0)
+
+        clock = Clock()
+
+        d = retry_failure(clock, function, expected=[ValueError], steps=steps)
+        self.assertNoResult(d)
+
+        clock.advance(0.1)
+        self.assertEqual(self.failureResultOf(d), type_error)
+
+
+class PollUntilTests(TestCase):
+    """
+    Tests for ``poll_until``.
+    """
+
+    def test_no_sleep_if_initially_true(self):
+        """
+        If the predicate starts off as True then we don't delay at all.
+        """
+        sleeps = []
+        poll_until(lambda: True, repeat(1), sleeps.append)
+        self.assertEqual([], sleeps)
+
+    def test_polls_until_true(self):
+        """
+        The predicate is repeatedly call until the result is truthy, delaying
+        by the interval each time.
+        """
+        sleeps = []
+        results = [False, False, True]
+        result = poll_until(lambda: results.pop(0), repeat(1), sleeps.append)
+        self.assertEqual((True, [1, 1]), (result, sleeps))
+
+    def test_default_sleep(self):
+        """
+        The ``poll_until`` function can be called with two arguments.
+        """
+        results = [False, True]
+        result = poll_until(lambda: results.pop(0), repeat(0))
+        self.assertEqual(True, result)
+
+    def test_loop_exceeded(self):
+        """
+        If the iterable of intervals that we pass to ``poll_until`` is
+        exhausted before we get a truthy return value, then we raise
+        ``LoopExceeded``.
+        """
+        results = [False] * 5
+        steps = [0.1] * 3
+        self.assertRaises(
+            LoopExceeded, poll_until, lambda: results.pop(0), steps,
+            lambda ignored: None)
+
+    def test_polls_one_last_time(self):
+        """
+        After intervals are exhausted, we poll one final time before
+        abandoning.
+        """
+        # Three sleeps, one value to poll after the last sleep.
+        results = [False, False, False, 42]
+        steps = [0.1] * 3
+        self.assertEqual(
+            42,
+            poll_until(lambda: results.pop(0), steps, lambda ignored: None))
+
+
+class RetryEffectTests(TestCase):
+    """
+    Tests for :py:func:`retry_effect_with_timeout`.
+    """
+    def get_time(self, times=None):
+        if times is None:
+            times = [1.0, 2.0, 3.0, 4.0, 5.0]
+
+        def fake_time():
+            return times.pop(0)
+        return fake_time
+
+    def test_immediate_success(self):
+        """
+        If the wrapped effect succeeds at first, no delay or retry is done and
+        the retry effect's result is the wrapped effect's result.
+        """
+        effect = Effect(Constant(1000))
+        retrier = retry_effect_with_timeout(effect, 10, time=self.get_time())
+        result = perform_sequence([], retrier)
+        self.assertEqual(result, 1000)
+
+    def test_one_retry(self):
+        """
+        Retry the effect if it fails once.
+        """
+        divisors = [0, 1]
+
+        def tester():
+            x = divisors.pop(0)
+            return 1 / x
+
+        seq = [
+            (Delay(1), lambda ignore: None),
+        ]
+
+        retrier = retry_effect_with_timeout(Effect(Func(tester)), 10,
+                                            time=self.get_time())
+        result = perform_sequence(seq, retrier)
+        self.assertEqual(result, 1 / 1)
+
+    def test_exponential_backoff(self):
+        """
+        Retry the effect multiple times with exponential backoff between
+        retries.
+        """
+        divisors = [0, 0, 0, 1]
+
+        def tester():
+            x = divisors.pop(0)
+            return 1 / x
+
+        seq = [
+            (Delay(1), lambda ignore: None),
+            (Delay(2), lambda ignore: None),
+            (Delay(4), lambda ignore: None),
+        ]
+
+        retrier = retry_effect_with_timeout(
+            Effect(Func(tester)), timeout=10, time=self.get_time(),
+        )
+        result = perform_sequence(seq, retrier)
+        self.assertEqual(result, 1)
+
+    def test_no_exponential_backoff(self):
+        """
+        If ``False`` is passed for the ``backoff`` parameter, the effect is
+        always retried with the same delay.
+        """
+        divisors = [0, 0, 0, 1]
+
+        def tester():
+            x = divisors.pop(0)
+            return 1 / x
+
+        seq = [
+            (Delay(5), lambda ignore: None),
+            (Delay(5), lambda ignore: None),
+            (Delay(5), lambda ignore: None),
+        ]
+
+        retrier = retry_effect_with_timeout(
+            Effect(Func(tester)), timeout=1, retry_wait=timedelta(seconds=5),
+            backoff=False,
+        )
+        result = perform_sequence(seq, retrier)
+        self.assertEqual(result, 1)
+
+    def test_timeout(self):
+        """
+        If the timeout expires, the retry effect fails with the exception from
+        the final time the wrapped effect is performed.
+        """
+        expected_intents = [
+            (Delay(1), lambda ignore: None),
+            (Delay(2), lambda ignore: None),
+        ]
+
+        exceptions = [
+            Exception("Wrong (1)"),
+            Exception("Wrong (2)"),
+            CustomException(),
+        ]
+
+        def tester():
+            raise exceptions.pop(0)
+
+        retrier = retry_effect_with_timeout(
+            Effect(Func(tester)),
+            timeout=3,
+            time=self.get_time([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),
+        )
+
+        self.assertRaises(
+            CustomException,
+            perform_sequence, expected_intents, retrier
+        )
+
+    def test_timeout_measured_from_perform(self):
+        """
+        The timeout is measured from the time the effect is performed (not from
+        the time it is created).
+        """
+        timeout = 3.0
+        time = self.get_time([0.0] + list(timeout + i for i in range(10)))
+
+        exceptions = [Exception("One problem")]
+        result = object()
+
+        def tester():
+            if exceptions:
+                raise exceptions.pop()
+            return result
+
+        retrier = retry_effect_with_timeout(
+            Effect(Func(tester)),
+            timeout=3,
+            time=time,
+        )
+
+        # The retry effect has been created.  Advance time a little bit before
+        # performing it.
+        time()
+
+        expected_intents = [
+            # The first call raises an exception and should be retried even
+            # though (as a side-effect of the `time` call above) the timeout,
+            # as measured from when `retry_effect_with_timeout` was called, has
+            # already elapsed.
+            #
+            # There's no second intent because the second call to the function
+            # succeeds.
+            (Delay(1), lambda ignore: None),
+        ]
+        self.assertThat(
+            perform_sequence(expected_intents, retrier), Is(result)
+        )
+
+
+EXPECTED_RETRY_SOME_TIMES_RETRIES = 1200
+
+
+class GetDefaultRetryStepsTests(TestCase):
+    """
+    Tests for ``get_default_retry_steps``.
+    """
+    def test_steps(self):
+        """
+        ``get_default_retry_steps`` returns an iterator consisting of the given
+        delay repeated enough times to fill the given maximum time period.
+        """
+        delay = timedelta(seconds=3)
+        max_time = timedelta(minutes=3)
+        steps = list(get_default_retry_steps(delay, max_time))
+        self.assertThat(set(steps), Equals({delay}))
+        self.assertThat(sum(steps, timedelta()), Equals(max_time))
+
+    def test_default(self):
+        """
+        There are default values for the delay and maximum time parameters
+        accepted by ``get_default_retry_steps``.
+        """
+        steps = get_default_retry_steps()
+        self.assertThat(steps, AllMatch(IsInstance(timedelta)))
+        self.assertThat(steps, AllMatch(GreaterThan(timedelta())))
+
+
+class RetryIfTests(TestCase):
+    """
+    Tests for ``retry_if``.
+    """
+    def test_matches(self):
+        """
+        If the matching function returns ``True``, the retry predicate returned
+        by ``retry_if`` returns ``None``.
+        """
+        should_retry = retry_if(
+            lambda exception: isinstance(exception, CustomException)
+        )
+        self.assertThat(
+            should_retry(
+                CustomException, CustomException("hello, world"), None
+            ),
+            Equals(None),
+        )
+
+    def test_does_not_match(self):
+        """
+        If the matching function returns ``False``, the retry predicate
+        returned by ``retry_if`` re-raises the exception.
+        """
+        should_retry = retry_if(
+            lambda exception: not isinstance(exception, CustomException)
+        )
+        self.assertThat(
+            lambda: should_retry(
+                CustomException, CustomException("hello, world"), None
+            ),
+            raises(CustomException),
+        )
+
+
+class DecorateMethodsTests(TestCase):
+    """
+    Tests for ``decorate_methods``.
+    """
+    @staticmethod
+    def noop_wrapper(method):
+        return method
+
+    def test_data_descriptor(self):
+        """
+        Non-method attribute read access passes through to the wrapped object
+        and the result is the same as if no wrapping had taken place.
+        """
+        class Original(object):
+            class_attribute = object()
+
+            def __init__(self):
+                self.instance_attribute = object()
+
+        original = Original()
+        wrapper = decorate_methods(original, self.noop_wrapper)
+        self.expectThat(
+            wrapper.class_attribute,
+            Equals(original.class_attribute),
+        )
+        self.expectThat(
+            wrapper.instance_attribute,
+            Equals(original.instance_attribute),
+        )
+
+    def test_passthrough(self):
+        """
+        Methods called on the wrapper have the same arguments passed through to
+        the wrapped method and the result of the wrapped method returned if no
+        exception is raised.
+        """
+        class Original(object):
+            def some_method(self, a, b):
+                return (b, a)
+
+        a = object()
+        b = object()
+
+        wrapper = decorate_methods(Original(), self.noop_wrapper)
+        self.expectThat(
+            wrapper.some_method(a, b=b),
+            Equals((b, a)),
+        )
+
+
+class WithRetryTests(TestCase):
+    """
+    Tests for ``with_retry``.
+    """
+    class AlwaysFail(object):
+        failures = 0
+
+        def some_method(self):
+            self.failures += 1
+            raise CustomException(self.failures)
+
+    def always_failing(self, counter):
+        raise CustomException(next(counter))
+
+    def test_success(self):
+        """
+        If the wrapped method returns a value on the first call, the value is
+        returned and no retries are made.
+        """
+        time = []
+        sleep = time.append
+
+        expected = object()
+        another = object()
+        results = [another, expected]
+
+        wrapper = with_retry(results.pop, sleep=sleep)
+        actual = wrapper()
+
+        self.expectThat(actual, Equals(expected))
+        self.expectThat(results, Equals([another]))
+
+    def test_default_retry(self):
+        """
+        If no value is given for the ``should_retry`` parameter, if the wrapped
+        method raises an exception it is called again after a short delay.
+        This is repeated using the elements of ``retry_some_times`` as the
+        sleep times and stops when there are no more elements.
+        """
+        time = []
+        sleep = time.append
+
+        counter = iter(count())
+        wrapper = with_retry(
+            partial(self.always_failing, counter), sleep=sleep
+        )
+        # XXX testtools ``raises`` helper generates a crummy message when this
+        # assertion fails
+        self.assertRaises(CustomException, wrapper)
+        self.expectThat(
+            next(counter),
+            # The number of times we demonstrated (above) that retry_some_times
+            # retries - plus one more for the initial call.
+            Equals(EXPECTED_RETRY_SOME_TIMES_RETRIES + 1),
+        )
+        self.expectThat(
+            sum(time),
+            # Floating point maths.  Allow for some slop.
+            MatchesPredicate(
+                lambda t: 119.8 <= t <= 120.0,
+                "Time value %r too far from expected value 119.9",
+            ),
+        )
+
+    def test_steps(self):
+        """
+        If an iterator of steps is passed to ``with_retry``, it is used to
+        determine the number of retries and the duration of the sleeps between
+        retries.
+        """
+        s = timedelta(seconds=1)
+        sleeps = []
+        wrapper = with_retry(
+            partial(self.always_failing, count()),
+            sleep=sleeps.append,
+            steps=[s * 1, s * 2, s * 3],
+        )
+        self.assertRaises(CustomException, wrapper)
+        self.expectThat(sleeps, Equals([1, 2, 3]))
+
+    def test_custom_should_retry(self):
+        """
+        If a predicate is passed for ``should_retry``, it used to determine
+        whether a retry should be attempted any time an exception is raised.
+        """
+        counter = iter(count())
+        original = partial(self.always_failing, counter)
+        wrapped = with_retry(
+            original,
+            should_retry=retry_if(
+                lambda exception: (
+                    isinstance(exception, CustomException) and
+                    exception.args[0] < 10
+                ),
+            ),
+            sleep=lambda interval: None,
+        )
+
+        self.expectThat(wrapped, raises(CustomException))
+        self.expectThat(next(counter), Equals(11))
+
+
+def greater_than_zero():
+    """
+    A strategy that yields floats greater than zero.
+    """
+    return st.floats(
+        min_value=0.0,
+        allow_infinity=False,
+    ).filter(lambda x: x > 0.0)
+
+
+class BackoffTests(TestCase):
+    """
+    Tests for ``backoff``.
+    """
+    def test_defaults(self):
+        """
+        ``backoff`` has sane default arguments:
+        """
+        expected_values = map(
+            float,
+            [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 60, 60, 60],
+        )
+        actual_values = list(backoff())
+        # Default jitter: 0.2
+        self.assertNotEqual(
+            expected_values,
+            actual_values
+        )
+        rounded_values = map(round, actual_values)
+        # Default step: 5.0
+        # Default maximum_step: 60
+        self.assertEqual(
+            expected_values,
+            rounded_values,
+        )
+        # Default timeout: 600s (10min)
+        self.assertEqual(
+            570.0,
+            sum(rounded_values)
+        )
+
+    @given(st.floats(max_value=0.0))
+    def test_min_step_size(self, step):
+        """
+        ``step`` must be greater than zero.
+        """
+        self.assertRaises(
+            ValueError,
+            backoff, step=step
+        )
+
+    @given(
+        greater_than_zero()
+    )
+    def test_step(self, step):
+        """
+        Successive values increase by ``step``.
+        """
+        b = backoff(step=step, maximum_step=None, timeout=None, jitter=None)
+        self.assertEqual(
+            list(
+                step * i
+                for i in range(1, 11)
+            ),
+            list(islice(b, 0, 10))
+        )
+
+    @given(st.floats(max_value=0.0))
+    def test_min_maximum_step_size(self, maximum_step):
+        """
+        ``maximum_step`` must be greater than zero.
+        """
+        self.assertRaises(
+            ValueError,
+            backoff, step=1.0, maximum_step=maximum_step
+        )
+
+    @given(
+        greater_than_zero(),
+        greater_than_zero(),
+    )
+    def test_maximum_step(self, step, maximum_step):
+        """
+        Successive values increase by ``step`` up to ``maximum_step``.
+        """
+        b = backoff(step=step, maximum_step=maximum_step,
+                    timeout=None, jitter=None)
+        self.assertEqual(
+            list(
+                min(maximum_step, step * i)
+                for i in range(1, 101)
+            ),
+            list(islice(b, 0, 100))
+        )
+
+    @given(
+        greater_than_zero().filter(lambda x: x > 1.0),
+        st.floats(min_value=0.0, max_value=5*60.0),
+    )
+    def test_timeout(self, step, timeout):
+        """
+        The sum of the generated values is never greater than ``timeout``.
+        """
+        b = backoff(step=step, maximum_step=None,
+                    timeout=timeout, jitter=None)
+        self.assertLessEqual(sum(b), timeout)
+
+    @given(
+        greater_than_zero(),
+        st.floats(min_value=0.0, allow_infinity=False),
+    )
+    def test_jitter(self, step, jitter):
+        """
+        When ``jitter`` is specified, the values will all be within +/-
+        ``jitter``.
+        """
+        jitter_values = backoff(
+            step=step,
+            jitter=jitter,
+            maximum_step=None,
+            timeout=None,
+        )
+
+        non_jitter_values = backoff(
+            step=step,
+            jitter=None,
+            maximum_step=None,
+            timeout=None,
+        )
+
+        some_values = islice(
+            izip(jitter_values, non_jitter_values),
+            0, 10
+        )
+        for x, y in some_values:
+            assume(float('inf') not in (x, y))
+            difference = abs(x - y)
+            self.assertLessEqual(
+                difference,
+                jitter * 2,
+                "x: {!r}, y: {!r}".format(x, y)
+            )

--- a/lae_util/testtools/__init__.py
+++ b/lae_util/testtools/__init__.py
@@ -1,0 +1,956 @@
+# Copyright 2014-2016 ClusterHQ
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+"""
+Various utilities to help with unit and functional testing.
+
+Originally ``flocker/testtools/__init__.py``.
+"""
+
+import gc
+import io
+import socket
+import sys
+import os
+import pwd
+from collections import namedtuple
+from contextlib import contextmanager
+from random import randrange
+import shutil
+from functools import wraps
+from unittest import skipIf, skipUnless
+from StringIO import StringIO
+
+from bitmath import MiB
+
+from pyrsistent import PClass, field
+
+from docker import Client as DockerClient
+from eliot import ActionType, MessageType, fields
+from eliot.twisted import DeferredContext
+
+from zope.interface import implementer
+from zope.interface.verify import verifyClass, verifyObject
+
+from twisted.internet.interfaces import (
+    IProcessTransport, IReactorProcess, IReactorCore,
+)
+from twisted.python.filepath import FilePath, Permissions
+from twisted.internet.base import _ThreePhaseEvent
+from twisted.internet.task import Clock
+from twisted.internet.defer import Deferred
+from twisted.internet.error import ConnectionDone
+from twisted.internet import reactor
+from twisted.trial.unittest import SkipTest
+from twisted.internet.protocol import Factory, ProcessProtocol, Protocol
+from twisted.test.proto_helpers import MemoryReactor
+from twisted.python.procutils import which
+from twisted.python.logfile import LogFile
+
+from ._base import (
+    AsyncTestCase, TestCase, async_runner, extract_eliot_from_twisted_log,
+)
+from ._flaky import flaky
+from .. import __version__
+from ..common import RACKSPACE_MINIMUM_VOLUME_SIZE
+from ..common.script import FlockerScriptRunner, ICommandLineScript
+from ..common.process import (
+    _ProcessResult, _CalledProcessError, run_process
+)
+
+__all__ = [
+    'AsyncTestCase',
+    'CustomException',
+    'DockerImageBuilder',
+    'FakeProcessReactor',
+    'FakeSysModule',
+    'MemoryCoreReactor',
+    'REALISTIC_BLOCKDEVICE_SIZE',
+    'make_standard_options_test',
+    'TestCase',
+    'assertContainsAll',
+    'assertNoFDsLeaked',
+    'assert_equal_comparison',
+    'assert_not_equal_comparison',
+    'async_runner',
+    'attempt_effective_uid',
+    'extract_eliot_from_twisted_log',
+    'find_free_port',
+    'flaky',
+    'help_problems',
+    'if_root',
+    'logged_run_process',
+    'make_script_tests',
+    'make_with_init_tests',
+    'not_root',
+    'random_name',
+    # XXX Refactor code that imports run_process from here.
+    'run_process',
+    'skip_on_broken_permissions',
+]
+
+REALISTIC_BLOCKDEVICE_SIZE = RACKSPACE_MINIMUM_VOLUME_SIZE
+
+
+@implementer(IProcessTransport)
+class FakeProcessTransport(object):
+    """
+    Mock process transport to observe signals sent to a process.
+
+    @ivar signals: L{list} of signals sent to process.
+    """
+
+    def __init__(self):
+        self.signals = []
+        self.stdin_open = [True]
+
+    def signalProcess(self, signal):
+        self.signals.append(signal)
+
+    def closeStdin(self):
+        self.stdin_open.append(False)
+
+
+class SpawnProcessArguments(namedtuple(
+                            'ProcessData',
+                            'processProtocol executable args env path '
+                            'uid gid usePTY childFDs transport')):
+    """
+    Object recording the arguments passed to L{FakeProcessReactor.spawnProcess}
+    as well as the L{IProcessTransport} that was connected to the protocol.
+
+    @ivar transport: Fake transport connected to the protocol.
+    @type transport: L{IProcessTransport}
+
+    @see L{twisted.internet.interfaces.IReactorProcess.spawnProcess}
+    """
+
+
+@implementer(IReactorProcess)
+class FakeProcessReactor(Clock):
+    """
+    Fake reactor implmenting process support.
+
+    @ivar processes: List of process that have been spawned
+    @type processes: L{list} of L{SpawnProcessArguments}.
+    """
+
+    def __init__(self):
+        Clock.__init__(self)
+        self.processes = []
+
+    def timeout(self):
+        if self.calls:
+            return max(0, self.calls[0].getTime() - self.seconds())
+        return 0
+
+    def spawnProcess(self, processProtocol, executable, args=(), env={},
+                     path=None, uid=None, gid=None, usePTY=0, childFDs=None):
+        transport = FakeProcessTransport()
+        self.processes.append(SpawnProcessArguments(
+            processProtocol, executable, args, env, path, uid, gid, usePTY,
+            childFDs, transport=transport))
+        processProtocol.makeConnection(transport)
+        return transport
+
+
+verifyClass(IReactorProcess, FakeProcessReactor)
+
+
+@contextmanager
+def assertNoFDsLeaked(test_case):
+    """Context manager that asserts no file descriptors are leaked.
+
+    :param test_case: The ``TestCase`` running this unit test.
+    :raise SkipTest: when /dev/fd virtual filesystem is not available.
+    """
+    # Make sure there's no file descriptors that will be cleared by GC
+    # later on:
+    gc.collect()
+
+    def process_fds():
+        path = FilePath(b"/dev/fd")
+        if not path.exists():
+            raise SkipTest("/dev/fd is not available.")
+
+        return set([child.basename() for child in path.children()])
+
+    fds = process_fds()
+    try:
+        yield
+    finally:
+        test_case.assertEqual(process_fds(), fds)
+
+
+def assert_equal_comparison(case, a, b):
+    """
+    Assert that ``a`` equals ``b``.
+
+    :param a: Any object to compare to ``b``.
+    :param b: Any object to compare to ``a``.
+
+    :raise: If ``a == b`` evaluates to ``False`` or if ``a != b`` evaluates to
+        ``True``, ``case.failureException`` is raised.
+    """
+    equal = a == b
+    unequal = a != b
+
+    messages = []
+    if not equal:
+        messages.append("a == b evaluated to False")
+    if unequal:
+        messages.append("a != b evaluated to True")
+
+    if messages:
+        case.fail(
+            "Expected a and b to be equal: " + "; ".join(messages))
+
+
+def assert_not_equal_comparison(case, a, b):
+    """
+    Assert that ``a`` does not equal ``b``.
+
+    :param a: Any object to compare to ``b``.
+    :param b: Any object to compare to ``a``.
+
+    :raise: If ``a == b`` evaluates to ``True`` or if ``a != b`` evaluates to
+        ``False``, ``case.failureException`` is raised.
+    """
+    equal = a == b
+    unequal = a != b
+
+    messages = []
+    if equal:
+        messages.append("a == b evaluated to True")
+    if not unequal:
+        messages.append("a != b evaluated to False")
+
+    if messages:
+        case.fail(
+            "Expected a and b to be not-equal: " + "; ".join(messages))
+
+
+def random_name(case):
+    """
+    Return a short, random name.
+
+    :param TestCase case: The test case being run.  The test method that is
+        running will be mixed into the name.
+
+    :return name: A random ``unicode`` name.
+    """
+    return u"{}-{}".format(case.id().replace(u".", u"_"), randrange(10 ** 6))
+
+
+def help_problems(command_name, help_text):
+    """Identify and return a list of help text problems.
+
+    :param unicode command_name: The name of the command which should appear in
+        the help text.
+    :param bytes help_text: The full help text to be inspected.
+    :return: A list of problems found with the supplied ``help_text``.
+    :rtype: list
+    """
+    problems = []
+    expected_start = u'Usage: {command}'.format(
+        command=command_name).encode('utf8')
+    if not help_text.startswith(expected_start):
+        problems.append(
+            'Does not begin with {expected}. Found {actual} instead'.format(
+                expected=repr(expected_start),
+                actual=repr(help_text[:len(expected_start)])
+            )
+        )
+    return problems
+
+
+class FakeSysModule(object):
+    """A ``sys`` like substitute.
+
+    For use in testing the handling of `argv`, `stdout` and `stderr` by command
+    line scripts.
+
+    :ivar list argv: See ``__init__``
+    :ivar stdout: A :py:class:`io.BytesIO` object representing standard output.
+    :ivar stderr: A :py:class:`io.BytesIO` object representing standard error.
+    """
+    def __init__(self, argv=None):
+        """Initialise the fake sys module.
+
+        :param list argv: The arguments list which should be exposed as
+            ``sys.argv``.
+        """
+        if argv is None:
+            argv = []
+        self.argv = argv
+        # io.BytesIO is not quite the same as sys.stdout/stderr
+        # particularly with respect to unicode handling.  So,
+        # hopefully the implementation doesn't try to write any
+        # unicode.
+        self.stdout = io.BytesIO()
+        self.stderr = io.BytesIO()
+
+
+def make_flocker_script_test(script, options, command_name):
+    """
+    Return a ``FlockerScriptTestCase`` which tests that the script
+    class provides ICommandLineScript
+
+    :param ICommandLineScript script: The script class under test.
+    :param usage.Options options: The options parser class to use in the test.
+    :param text command_name: The name of the command represented by
+    ``script``.
+
+    :returns: A ``TestCase``.
+    """
+    class FlockerScriptTestCase(TestCase):
+        """
+        Test for classes that implement ``ICommandLineScript``
+        """
+
+        def test_interface(self):
+            """
+            A script that is meant to be run by ``FlockerScriptRunner`` must
+            implement ``ICommandLineScript``.
+            """
+            self.assertTrue(verifyObject(ICommandLineScript, script()))
+
+        def test_incorrect_arguments(self):
+            """
+            ``FlockerScriptRunner.main`` exits with status 1 and prints help to
+            `stderr` if supplied with unexpected arguments.
+            """
+            sys_module = FakeSysModule(
+                argv=[command_name, b'--unexpected_argument'])
+            script_runner = FlockerScriptRunner(
+                reactor=None, script=script(), options=options(),
+                sys_module=sys_module)
+            error = self.assertRaises(SystemExit, script_runner.main)
+            error_text = sys_module.stderr.getvalue()
+            self.assertEqual(
+                (1, []),
+                (error.code, help_problems(command_name, error_text))
+            )
+
+    return FlockerScriptTestCase
+
+
+def make_standard_options_test(options):
+    """
+    Return a ``StandardOptionsTestCase`` which tests that the passed in
+    options class provides the expected defaults and basic functionality.
+
+    :ivar usage.Options options: The ``usage.Options`` class under test.
+
+    :returns: a ``TestCase``
+    """
+    class StandardOptionsTestCase(TestCase):
+        """
+        Tests for the standard options that should be available for every
+        flocker command.
+        """
+        def test_sys_module_default(self):
+            """
+            ``flocker_standard_options`` adds a ``_sys_module`` attribute
+            which is ``sys`` by default.
+            """
+            self.assertIs(sys, options()._sys_module)
+
+        def test_sys_module_override(self):
+            """
+            ``flocker_standard_options`` adds a ``sys_module`` argument to the
+            initialiser which is assigned to ``_sys_module``.
+            """
+            fake_sys_module = FakeSysModule()
+            self.assertIs(
+                fake_sys_module,
+                options(sys_module=fake_sys_module)._sys_module
+            )
+
+        def test_version(self):
+            """
+            Flocker commands have a `--version` option which prints the current
+            version string to stdout and causes the command to exit with status
+            `0`.
+            """
+            sys = FakeSysModule()
+            error = self.assertRaises(
+                SystemExit,
+                options(sys_module=sys).parseOptions,
+                ['--version']
+            )
+            self.assertEqual(
+                (__version__ + '\n', 0),
+                (sys.stdout.getvalue(), error.code)
+            )
+
+        def test_verbosity_default(self):
+            """
+            Flocker commands have `verbosity` of `0` by default.
+            """
+            options_instance = options()
+            self.assertEqual(0, options_instance['verbosity'])
+
+        def test_verbosity_option(self):
+            """
+            Flocker commands have a `--verbose` option which increments the
+            configured verbosity by `1`.
+            """
+            options_instance = options()
+            # The command may otherwise give a UsageError "Wrong
+            # number of arguments." if there are arguments required.
+            # See https://clusterhq.atlassian.net/browse/FLOC-184
+            # about a solution which does not involve patching.
+            self.patch(options_instance, "parseArgs", lambda: None)
+            options_instance.parseOptions(['--verbose'])
+            self.assertEqual(1, options_instance['verbosity'])
+
+        def test_verbosity_option_short(self):
+            """
+            Flocker commands have a `-v` option which increments the configured
+            verbosity by 1.
+            """
+            options_instance = options()
+            # The command may otherwise give a UsageError "Wrong
+            # number of arguments." if there are arguments required.
+            # See https://clusterhq.atlassian.net/browse/FLOC-184
+            # about a solution which does not involve patching.
+            self.patch(options_instance, "parseArgs", lambda: None)
+            options_instance.parseOptions(['-v'])
+            self.assertEqual(1, options_instance['verbosity'])
+
+        def test_verbosity_multiple(self):
+            """
+            `--verbose` can be supplied multiple times to increase the
+            verbosity.
+            """
+            options_instance = options()
+            # The command may otherwise give a UsageError "Wrong
+            # number of arguments." if there are arguments required.
+            # See https://clusterhq.atlassian.net/browse/FLOC-184
+            # about a solution which does not involve patching.
+            self.patch(options_instance, "parseArgs", lambda: None)
+            options_instance.parseOptions(['-v', '--verbose'])
+            self.assertEqual(2, options_instance['verbosity'])
+
+        def test_logfile_default(self):
+            """
+            `--logfile` is optional and if ommited, logs will be directed to
+            ``stdout``.
+            """
+            sys = FakeSysModule()
+            options_instance = options(sys_module=sys)
+            # The command may otherwise give a UsageError "Wrong
+            # number of arguments." if there are arguments required.
+            # See https://clusterhq.atlassian.net/browse/FLOC-184
+            # about a solution which does not involve patching.
+            self.patch(options_instance, "parseArgs", lambda: None)
+            options_instance.parseOptions([])
+            self.assertIs(sys.stdout, options_instance.eliot_destination.file)
+
+        def test_logfile_override(self):
+            """
+            If `--logfile` is supplied, the Eliot logging destination wraps
+            ``twisted.python.logfile.LogFile``.
+            """
+            options_instance = options()
+            # The command may otherwise give a UsageError "Wrong
+            # number of arguments." if there are arguments required.
+            # See https://clusterhq.atlassian.net/browse/FLOC-184
+            # about a solution which does not involve patching.
+            self.patch(options_instance, "parseArgs", lambda: None)
+            expected_path = FilePath(self.mktemp()).path
+            options_instance.parseOptions(
+                ['--logfile={}'.format(expected_path)]
+            )
+            logfile = options_instance.eliot_destination.file
+            self.assertEqual(
+                (LogFile, expected_path, int(MiB(100).to_Byte().value), 5),
+                (logfile.__class__, logfile.path,
+                 logfile.rotateLength, logfile.maxRotatedFiles)
+            )
+
+    return StandardOptionsTestCase
+
+
+def make_with_init_tests(record_type, kwargs, expected_defaults=None):
+    """
+    Return a ``TestCase`` which tests that ``record_type.__init__`` accepts the
+    supplied ``kwargs`` and exposes them as public attributes.
+
+    :param record_type: The class with an ``__init__`` method to be tested.
+    :param kwargs: The keyword arguments which will be supplied to the
+        ``__init__`` method.
+    :param dict expected_defaults: The default keys and default values of
+        arguments which have defaults and which may be omitted when calling the
+        initialiser.
+    :returns: A ``TestCase``.
+    """
+    if expected_defaults is None:
+        expected_defaults = {}
+
+    unknown_defaults = set(expected_defaults.keys()) - set(kwargs.keys())
+    if unknown_defaults:
+        raise TypeError(
+            'expected_defaults contained the following unrecognized keys: '
+            '{}'.format(tuple(unknown_defaults)))
+
+    required_kwargs = kwargs.copy()
+    for k in expected_defaults.keys():
+        required_kwargs.pop(k)
+
+    class WithInitTests(TestCase):
+        """
+        Tests for classes decorated with ``with_init``.
+        """
+        def test_init(self):
+            """
+            The record type accepts keyword arguments which are exposed as
+            public attributes.
+            """
+            record = record_type(**kwargs)
+            self.assertEqual(
+                kwargs.values(),
+                [getattr(record, key) for key in kwargs.keys()]
+            )
+
+        def test_optional_arguments(self):
+            """
+            The record type initialiser has arguments which may be omitted.
+            """
+            try:
+                record = record_type(**required_kwargs)
+            except ValueError as e:
+                self.fail(
+                    'One of the following arguments was expected to be '
+                    'optional but appears to be required: %r. '
+                    'Error was: %r' % (
+                        expected_defaults.keys(), e))
+
+            self.assertEqual(
+                required_kwargs.values(),
+                [getattr(record, key) for key in required_kwargs.keys()]
+            )
+
+        def test_optional_defaults(self):
+            """
+            The optional arguments have the expected defaults.
+            """
+            try:
+                record = record_type(**required_kwargs)
+            except ValueError as e:
+                self.fail(
+                    'One of the following arguments was expected to be '
+                    'optional but appears to be required: %r. '
+                    'Error was: %r' % (
+                        expected_defaults.keys(), e))
+            self.assertEqual(
+                expected_defaults.values(),
+                [getattr(record, key) for key in expected_defaults.keys()]
+            )
+
+    return WithInitTests
+
+
+def find_free_port(interface='127.0.0.1', socket_family=socket.AF_INET,
+                   socket_type=socket.SOCK_STREAM):
+    """
+    Ask the platform to allocate a free port on the specified interface, then
+    release the socket and return the address which was allocated.
+
+    Copied from ``twisted.internet.test.connectionmixins.findFreePort``.
+
+    :param bytes interface: The local address to try to bind the port on.
+    :param int socket_family: The socket family of port.
+    :param int socket_type: The socket type of the port.
+
+    :return: A two-tuple of address and port, like that returned by
+        ``socket.getsockname``.
+    """
+    address = socket.getaddrinfo(interface, 0)[0][4]
+    probe = socket.socket(socket_family, socket_type)
+    try:
+        probe.bind(address)
+        return probe.getsockname()
+    finally:
+        probe.close()
+
+
+def make_capture_protocol():
+    """
+    Return a ``Deferred``, and a ``Protocol`` which will capture bytes and fire
+    the ``Deferred`` when its connection is lost.
+
+    :returns: A 2-tuple of ``Deferred`` and ``Protocol`` instance.
+    :rtype: tuple
+    """
+    d = Deferred()
+    captured_data = []
+
+    class Recorder(Protocol):
+        def dataReceived(self, data):
+            captured_data.append(data)
+
+        def connectionLost(self, reason):
+            if reason.check(ConnectionDone):
+                d.callback(b''.join(captured_data))
+            else:
+                d.errback(reason)
+    return d, Recorder()
+
+
+class ProtocolPoppingFactory(Factory):
+    """
+    A factory which only creates a fixed list of protocols.
+
+    For example if in a test you want to ensure that a test server only handles
+    a single connection, you'd supply a list of one ``Protocol``
+    instance. Subsequent requests will result in an ``IndexError``.
+    """
+    def __init__(self, protocols):
+        """
+        :param list protocols: A list of ``Protocol`` instances which will be
+            used for successive connections.
+        """
+        self.protocols = protocols
+
+    def buildProtocol(self, addr):
+        return self.protocols.pop()
+
+
+class DockerImageBuilder(PClass):
+    """
+    Build a docker image, tag it, and remove the image later.
+
+    :ivar TestCase test: The test the builder is being used in.
+    :ivar FilePath source_dir: The path to the directory containing a
+        ``Dockerfile.in`` file.
+    :ivar bool cleanup: If ``True`` then cleanup after the test is done.
+    """
+    test = field(mandatory=True)
+    source_dir = field(mandatory=True)
+    cleanup = field(mandatory=True, initial=True)
+
+    def _process_template(self, template_file, target_file, replacements):
+        """
+        Fill in the placeholders in `template_file` with the `replacements` and
+        write the result to `target_file`.
+
+        :param FilePath template_file: The file containing the placeholders.
+        :param FilePath target_file: The file to which the result will be
+            written.
+        :param dict replacements: A dictionary of variable names and
+            replacement values.
+        """
+        with template_file.open() as f:
+            template = f.read().decode('utf8')
+        target_file.setContent(template.format(**replacements))
+
+    def build(self, dockerfile_variables=None):
+        """
+        Build an image and tag it in the local Docker repository.
+
+        :param dict dockerfile_variables: A dictionary of replacements which
+            will be applied to a `Dockerfile.in` template file if such a file
+            exists.
+
+        :return: ``Deferred bytes`` with the tag name applied to the built
+            image.
+        """
+        if dockerfile_variables is None:
+            dockerfile_variables = {}
+
+        working_dir = FilePath(self.test.mktemp())
+        working_dir.makedirs()
+
+        docker_dir = working_dir.child('docker')
+        shutil.copytree(self.source_dir.path, docker_dir.path)
+        template_file = docker_dir.child('Dockerfile.in')
+        docker_file = docker_dir.child('Dockerfile')
+        if template_file.exists() and not docker_file.exists():
+            self._process_template(
+                template_file, docker_file, dockerfile_variables)
+        tag = b"flockerlocaltests/" + random_name(self.test).lower()
+
+        # XXX: This dumps lots of debug output to stderr which messes up the
+        # test results output. It's useful debug info incase of a test failure
+        # so it would be better to send it to the test.log file. See
+        # https://clusterhq.atlassian.net/browse/FLOC-171
+        command = [
+            b'docker', b'build',
+            # Always clean up intermediate containers in case of failures.
+            b'--force-rm',
+            b'--tag=%s' % (tag,),
+            docker_dir.path
+        ]
+        d = logged_run_process(reactor, command)
+        if self.cleanup:
+            def remove_image():
+                client = DockerClient(version="1.15")
+                for container in client.containers():
+                    if container[u"Image"] == tag + ":latest":
+                        client.remove_container(container[u"Names"][0])
+                client.remove_image(tag, force=True)
+            self.test.addCleanup(remove_image)
+        return d.addCallback(lambda ignored: tag)
+
+
+def skip_on_broken_permissions(test_method):
+    """
+    Skips the wrapped test when the temporary directory is on a
+    filesystem with broken permissions.
+
+    Virtualbox's shared folder (as used for :file:`/vagrant`) doesn't entirely
+    respect changing permissions. For example, this test detects running on a
+    shared folder by the fact that all permissions can't be removed from a
+    file.
+
+    :param callable test_method: Test method to wrap.
+    :return: The wrapped method.
+    :raise SkipTest: when the temporary directory is on a filesystem with
+        broken permissions.
+    """
+    @wraps(test_method)
+    def wrapper(case, *args, **kwargs):
+        test_file = FilePath(case.mktemp())
+        test_file.touch()
+        test_file.chmod(0o000)
+        permissions = test_file.getPermissions()
+        test_file.chmod(0o777)
+        if permissions != Permissions(0o000):
+            raise SkipTest(
+                "Can't run test on filesystem with broken permissions.")
+        return test_method(case, *args, **kwargs)
+    return wrapper
+
+
+@contextmanager
+def attempt_effective_uid(username, suppress_errors=False):
+    """
+    A context manager to temporarily change the effective user id.
+
+    :param bytes username: The username whose uid will take effect.
+    :param bool suppress_errors: Set to `True` to suppress `OSError`
+        ("Operation not permitted") when running as a non-root user.
+    """
+    original_euid = os.geteuid()
+    new_euid = pwd.getpwnam(username).pw_uid
+    restore_euid = False
+
+    if original_euid != new_euid:
+        try:
+            os.seteuid(new_euid)
+        except OSError as e:
+            # Only handle "Operation not permitted" errors.
+            if not suppress_errors or e.errno != 1:
+                raise
+        else:
+            restore_euid = True
+    try:
+        yield
+    finally:
+        if restore_euid:
+            os.seteuid(original_euid)
+
+
+def assertContainsAll(haystack, needles, test_case):
+    """
+    Assert that all the terms in the needles list are found in the haystack.
+
+    :param test_case: The ``TestCase`` instance on which to call assertions.
+    :param list needles: A list of terms to search for in the ``haystack``.
+    :param haystack: An iterable in which to search for the terms in needles.
+    """
+    for needle in reversed(needles):
+        if needle in haystack:
+            needles.remove(needle)
+
+    if needles:
+        test_case.fail(
+            '{haystack} did not contain {needles}'.format(
+                haystack=haystack, needles=needles
+            )
+        )
+
+
+# Skip decorators for tests:
+if_root = skipIf(os.getuid() != 0, "Must run as root.")
+not_root = skipIf(os.getuid() == 0, "Must not run as root.")
+
+
+# TODO: This should be provided by Twisted (also it should be more complete
+# instead of 1/3rd done).
+
+
+@implementer(IReactorCore)
+class MemoryCoreReactor(MemoryReactor, Clock):
+    """
+    Fake reactor with listenTCP, IReactorTime and just enough of an
+    implementation of IReactorCore.
+    """
+    def __init__(self):
+        MemoryReactor.__init__(self)
+        Clock.__init__(self)
+        self._triggers = {}
+
+    def addSystemEventTrigger(self, phase, eventType, f, *args, **kw):
+        event = self._triggers.setdefault(eventType, _ThreePhaseEvent())
+        return eventType, event.addTrigger(phase, f, *args, **kw)
+
+    def removeSystemEventTrigger(self, triggerID):
+        eventType, handle = triggerID
+        event = self._triggers.setdefault(eventType, _ThreePhaseEvent())
+        event.removeTrigger(handle)
+
+    def fireSystemEvent(self, eventType):
+        event = self._triggers.get(eventType)
+        if event is not None:
+            event.fireEvent()
+
+
+def make_script_tests(executable):
+    """
+    Generate a test suite which applies to any Flocker-installed node script.
+
+    :param bytes executable: The basename of the script to be tested.
+
+    :return: A ``TestCase`` subclass which defines some tests applied to the
+        given executable.
+    """
+    class ScriptTests(TestCase):
+        @skipUnless(which(executable), executable + " not installed")
+        def test_version(self):
+            """
+            The script is a command available on the system path.
+            """
+            result = run_process([executable] + [b"--version"])
+            self.assertEqual(result.output, b"%s\n" % (__version__,))
+
+        @skipUnless(which(executable), executable + " not installed")
+        def test_identification(self):
+            """
+            The script identifies itself as what it is.
+            """
+            result = run_process([executable] + [b"--help"])
+            self.assertIn(executable, result.output)
+    return ScriptTests
+
+
+class CustomException(Exception):
+    """
+    An exception that will never be raised by real code, useful for
+    testing.
+    """
+
+
+TWISTED_CHILD_PROCESS_ACTION = ActionType(
+    u'flocker:testtools:logged_run_process',
+    fields(command=list),
+    [],
+    u'A child process is spawned using Twisted',
+)
+
+STDOUT_RECEIVED = MessageType(
+    u'flocker:testtools:logged_run_process:stdout',
+    fields(output=str),
+    u'A chunk of stdout received from a child process',
+)
+
+STDERR_RECEIVED = MessageType(
+    u'flocker:testtools:logged_run_process:stdout',
+    fields(output=str),
+    u'A chunk of stderr received from a child process',
+)
+
+PROCESS_ENDED = MessageType(
+    u'flocker:testtools:logged_run_process:process_ended',
+    fields(status=int),
+    u'The process terminated')
+
+
+class _LoggingProcessProtocol(ProcessProtocol):
+    """
+    A ``ProcessProtocol`` that both stores and logs output from the
+    subprocess. Output is logged as it is received.
+
+    Intended to be used by ``logged_run_process``.
+    """
+
+    def __init__(self, deferred, action):
+        """
+        Construct a ``_LoggingProcessProtocol``.
+
+        :param deferred: A ``Deferred`` that will fire with
+            ``(reason, output)``
+            when the process ends, where ``reason`` is a ``Failure`` with the
+            reason for the process ending (see ``IProcessProtocol``), and
+            ``output`` are the bytes outputted by the process (both to stdout
+            and stderr).
+        :param action: The Eliot ``Action`` under which this process is being
+            run.
+        """
+        self._deferred = deferred
+        self._action = action
+        self._output_buffer = StringIO()
+
+    def outReceived(self, data):
+        with self._action.context():
+            self._output_buffer.write(data)
+            STDOUT_RECEIVED(output=data).write()
+
+    def errReceived(self, data):
+        with self._action.context():
+            self._output_buffer.write(data)
+            STDERR_RECEIVED(output=data).write()
+
+    def processExited(self, reason):
+        with self._action.context():
+            PROCESS_ENDED(status=reason.value.status).write()
+            self._deferred.callback((reason, self._output_buffer.getvalue()))
+
+
+def logged_run_process(reactor, command):
+    """
+    Run a child process, and log the output as we get it.
+
+    :param reactor: An ``IReactorProcess`` to spawn the process on.
+    :param command: An argument list specifying the child process to run.
+
+    :return: A ``Deferred`` that calls back with ``_ProcessResult`` if the
+        process exited successfully, or errbacks with
+        ``_CalledProcessError`` otherwise.
+    """
+    d = Deferred()
+    action = TWISTED_CHILD_PROCESS_ACTION(command=command)
+    with action.context():
+        d2 = DeferredContext(d)
+        protocol = _LoggingProcessProtocol(d, action)
+        reactor.spawnProcess(protocol, command[0], command)
+
+        def process_ended((reason, output)):
+            status = reason.value.status
+            if status:
+                raise _CalledProcessError(
+                    returncode=status, cmd=command, output=output)
+            return _ProcessResult(
+                command=command,
+                status=status,
+                output=output,
+            )
+
+        d2.addCallback(process_ended)
+        d2.addActionFinish()
+        return d2.result

--- a/lae_util/testtools/__init__.py
+++ b/lae_util/testtools/__init__.py
@@ -38,7 +38,6 @@ from bitmath import MiB
 
 from pyrsistent import PClass, field
 
-from docker import Client as DockerClient
 from eliot import ActionType, MessageType, fields
 from eliot.twisted import DeferredContext
 
@@ -74,7 +73,6 @@ from ..common.process import (
 __all__ = [
     'AsyncTestCase',
     'CustomException',
-    'DockerImageBuilder',
     'FakeProcessReactor',
     'FakeSysModule',
     'MemoryCoreReactor',
@@ -629,83 +627,6 @@ class ProtocolPoppingFactory(Factory):
 
     def buildProtocol(self, addr):
         return self.protocols.pop()
-
-
-class DockerImageBuilder(PClass):
-    """
-    Build a docker image, tag it, and remove the image later.
-
-    :ivar TestCase test: The test the builder is being used in.
-    :ivar FilePath source_dir: The path to the directory containing a
-        ``Dockerfile.in`` file.
-    :ivar bool cleanup: If ``True`` then cleanup after the test is done.
-    """
-    test = field(mandatory=True)
-    source_dir = field(mandatory=True)
-    cleanup = field(mandatory=True, initial=True)
-
-    def _process_template(self, template_file, target_file, replacements):
-        """
-        Fill in the placeholders in `template_file` with the `replacements` and
-        write the result to `target_file`.
-
-        :param FilePath template_file: The file containing the placeholders.
-        :param FilePath target_file: The file to which the result will be
-            written.
-        :param dict replacements: A dictionary of variable names and
-            replacement values.
-        """
-        with template_file.open() as f:
-            template = f.read().decode('utf8')
-        target_file.setContent(template.format(**replacements))
-
-    def build(self, dockerfile_variables=None):
-        """
-        Build an image and tag it in the local Docker repository.
-
-        :param dict dockerfile_variables: A dictionary of replacements which
-            will be applied to a `Dockerfile.in` template file if such a file
-            exists.
-
-        :return: ``Deferred bytes`` with the tag name applied to the built
-            image.
-        """
-        if dockerfile_variables is None:
-            dockerfile_variables = {}
-
-        working_dir = FilePath(self.test.mktemp())
-        working_dir.makedirs()
-
-        docker_dir = working_dir.child('docker')
-        shutil.copytree(self.source_dir.path, docker_dir.path)
-        template_file = docker_dir.child('Dockerfile.in')
-        docker_file = docker_dir.child('Dockerfile')
-        if template_file.exists() and not docker_file.exists():
-            self._process_template(
-                template_file, docker_file, dockerfile_variables)
-        tag = b"flockerlocaltests/" + random_name(self.test).lower()
-
-        # XXX: This dumps lots of debug output to stderr which messes up the
-        # test results output. It's useful debug info incase of a test failure
-        # so it would be better to send it to the test.log file. See
-        # https://clusterhq.atlassian.net/browse/FLOC-171
-        command = [
-            b'docker', b'build',
-            # Always clean up intermediate containers in case of failures.
-            b'--force-rm',
-            b'--tag=%s' % (tag,),
-            docker_dir.path
-        ]
-        d = logged_run_process(reactor, command)
-        if self.cleanup:
-            def remove_image():
-                client = DockerClient(version="1.15")
-                for container in client.containers():
-                    if container[u"Image"] == tag + ":latest":
-                        client.remove_container(container[u"Names"][0])
-                client.remove_image(tag, force=True)
-            self.test.addCleanup(remove_image)
-        return d.addCallback(lambda ignored: tag)
 
 
 def skip_on_broken_permissions(test_method):

--- a/lae_util/testtools/__init__.py
+++ b/lae_util/testtools/__init__.py
@@ -60,12 +60,10 @@ from twisted.python.procutils import which
 from twisted.python.logfile import LogFile
 
 from ._base import (
-    AsyncTestCase, TestCase, async_runner, extract_eliot_from_twisted_log,
+    TestCase, async_runner, extract_eliot_from_twisted_log,
 )
-from ._flaky import flaky
 
 __all__ = [
-    'AsyncTestCase',
     'CustomException',
     'FakeProcessReactor',
     'FakeSysModule',
@@ -80,7 +78,6 @@ __all__ = [
     'attempt_effective_uid',
     'extract_eliot_from_twisted_log',
     'find_free_port',
-    'flaky',
     'help_problems',
     'if_root',
     'make_with_init_tests',

--- a/lae_util/testtools/__init__.py
+++ b/lae_util/testtools/__init__.py
@@ -63,8 +63,6 @@ from ._base import (
     AsyncTestCase, TestCase, async_runner, extract_eliot_from_twisted_log,
 )
 from ._flaky import flaky
-from ..common import RACKSPACE_MINIMUM_VOLUME_SIZE
-from ..common.script import FlockerScriptRunner, ICommandLineScript
 from ..common.process import (
     _ProcessResult, _CalledProcessError, run_process
 )
@@ -75,7 +73,6 @@ __all__ = [
     'FakeProcessReactor',
     'FakeSysModule',
     'MemoryCoreReactor',
-    'REALISTIC_BLOCKDEVICE_SIZE',
     'make_standard_options_test',
     'TestCase',
     'assertContainsAll',
@@ -98,7 +95,6 @@ __all__ = [
     'skip_on_broken_permissions',
 ]
 
-REALISTIC_BLOCKDEVICE_SIZE = RACKSPACE_MINIMUM_VOLUME_SIZE
 
 
 @implementer(IProcessTransport)
@@ -298,50 +294,6 @@ class FakeSysModule(object):
         # unicode.
         self.stdout = io.BytesIO()
         self.stderr = io.BytesIO()
-
-
-def make_flocker_script_test(script, options, command_name):
-    """
-    Return a ``FlockerScriptTestCase`` which tests that the script
-    class provides ICommandLineScript
-
-    :param ICommandLineScript script: The script class under test.
-    :param usage.Options options: The options parser class to use in the test.
-    :param text command_name: The name of the command represented by
-    ``script``.
-
-    :returns: A ``TestCase``.
-    """
-    class FlockerScriptTestCase(TestCase):
-        """
-        Test for classes that implement ``ICommandLineScript``
-        """
-
-        def test_interface(self):
-            """
-            A script that is meant to be run by ``FlockerScriptRunner`` must
-            implement ``ICommandLineScript``.
-            """
-            self.assertTrue(verifyObject(ICommandLineScript, script()))
-
-        def test_incorrect_arguments(self):
-            """
-            ``FlockerScriptRunner.main`` exits with status 1 and prints help to
-            `stderr` if supplied with unexpected arguments.
-            """
-            sys_module = FakeSysModule(
-                argv=[command_name, b'--unexpected_argument'])
-            script_runner = FlockerScriptRunner(
-                reactor=None, script=script(), options=options(),
-                sys_module=sys_module)
-            error = self.assertRaises(SystemExit, script_runner.main)
-            error_text = sys_module.stderr.getvalue()
-            self.assertEqual(
-                (1, []),
-                (error.code, help_problems(command_name, error_text))
-            )
-
-    return FlockerScriptTestCase
 
 
 def make_with_init_tests(record_type, kwargs, expected_defaults=None):

--- a/lae_util/testtools/__init__.py
+++ b/lae_util/testtools/__init__.py
@@ -60,7 +60,7 @@ from twisted.python.procutils import which
 from twisted.python.logfile import LogFile
 
 from ._base import (
-    TestCase, async_runner, extract_eliot_from_twisted_log,
+    TestCase, extract_eliot_from_twisted_log,
 )
 
 __all__ = [
@@ -74,7 +74,6 @@ __all__ = [
     'assertNoFDsLeaked',
     'assert_equal_comparison',
     'assert_not_equal_comparison',
-    'async_runner',
     'attempt_effective_uid',
     'extract_eliot_from_twisted_log',
     'find_free_port',

--- a/lae_util/testtools/_base.py
+++ b/lae_util/testtools/_base.py
@@ -167,25 +167,6 @@ class _AsyncRunner(AsynchronousDeferredRunTestForBrokenTwisted):
         super(_AsyncRunner, self)._run_core()
 
 
-def async_runner(timeout):
-    """
-    Make a ``RunTest`` instance for asynchronous tests.
-
-    :param timedelta timeout: The maximum length of time that a test is allowed
-        to take.
-    """
-    # XXX: The acceptance tests (which were the first tests that we tried to
-    # migrate) aren't cleaning up after themselves even in the successful
-    # case. Use AsynchronousDeferredRunTestForBrokenTwisted, which loops the
-    # reactor a couple of times after the test is done.
-    async_factory = _AsyncRunner.make_factory(
-        timeout=timeout.total_seconds(),
-        suppress_twisted_logging=False,
-        store_twisted_logs=False,
-    )
-    return partial(RunTest, async_factory)
-
-
 def _test_skipped(case, result, exception):
     result.addSkip(case, details={'reason': text_content(unicode(exception))})
 

--- a/lae_util/testtools/_base.py
+++ b/lae_util/testtools/_base.py
@@ -1,0 +1,390 @@
+# Copyright 2014-2016 ClusterHQ
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Base classes for unit tests.
+
+Originally ``flocker/testtools/__base.py``.
+"""
+
+from datetime import timedelta
+from itertools import tee
+import json
+import tempfile
+from unittest import SkipTest
+
+from eliot.prettyprint import pretty_format
+from fixtures import Fixture
+import testtools
+from testtools.content import Content, text_content
+from testtools.content_type import UTF8_TEXT
+from testtools.twistedsupport import (
+    AsynchronousDeferredRunTestForBrokenTwisted, assert_fails_with,
+    CaptureTwistedLogs,
+)
+
+from twisted.python import log
+from twisted.python.filepath import FilePath
+from twisted.trial import unittest
+
+from ..common import make_file
+from ._flaky import retry_flaky
+
+
+class _MktempMixin(object):
+    """
+    ``mktemp`` support for testtools TestCases.
+    """
+
+    def mktemp(self):
+        """
+        Create a temporary path for use in tests.
+
+        Provided for compatibility with Twisted's ``TestCase``.
+
+        :return: Path to non-existent file or directory.
+        """
+        return self.make_temporary_path().path
+
+    def make_temporary_path(self):
+        """
+        Create a temporary path for use in tests.
+
+        :return: Path to non-existent file or directory.
+        :rtype: FilePath
+        """
+        return self.make_temporary_directory().child('temp')
+
+    def make_temporary_directory(self):
+        """
+        Create a temporary directory for use in tests.
+
+        :return: Path to directory.
+        :rtype: FilePath
+        """
+        return make_temporary_directory(_path_for_test(self))
+
+    def make_temporary_file(self, content='', permissions=None):
+        """
+        Create a temporary file for use in tests.
+
+        :param str content: Content to write to the file.
+        :param int permissions: The permissions for the file
+        :return: Path to file.
+        :rtype: FilePath
+        """
+        return make_file(self.make_temporary_path(), content, permissions)
+
+
+class _DeferredAssertionMixin(object):
+    """
+    Synchronous Deferred-related assertions support for testtools TestCase.
+
+    This is provided for compatibility with Twisted's TestCase.  New code
+    should use matchers instead.
+    """
+    successResultOf = unittest.SynchronousTestCase.successResultOf.__func__
+    failureResultOf = unittest.SynchronousTestCase.failureResultOf.__func__
+    assertNoResult = unittest.SynchronousTestCase.assertNoResult.__func__
+
+    # Not related to Deferreds but required by the implementation of the above.
+    assertIdentical = unittest.SynchronousTestCase.assertIdentical.__func__
+
+
+class TestCase(testtools.TestCase, _MktempMixin, _DeferredAssertionMixin):
+    """
+    Base class for synchronous test cases.
+    """
+
+    run_tests_with = retry_flaky(testtools.RunTest)
+    # Eliot's validateLogging hard-codes a check for SkipTest when deciding
+    # whether to check for valid logging, which is fair enough, since there's
+    # no other API for checking whether a test has skipped. Setting
+    # skipException tells testtools to treat unittest.SkipTest as the
+    # exception that signals skipping.
+    skipException = SkipTest
+
+    def setUp(self):
+        log.msg("--> Begin: %s <--" % (self.id()))
+        super(TestCase, self).setUp()
+        self.useFixture(_SplitEliotLogs())
+
+
+class _AsyncRunner(AsynchronousDeferredRunTestForBrokenTwisted):
+    """
+    Runner for asynchronous tests.
+
+    Extends base functionality to correctly capture logs for failed tests.
+    """
+
+    def _get_log_fixture(self):
+        """Return a fixture used to capture logs."""
+        # XXX: This is a hack, relying on the internal implementation details
+        # of AsynchronousDeferredRunTest.
+        #
+        # We want to use the _SplitEliotLogs fixture, but we want to make sure
+        # that it's set up & torn down *outside* the test itself.
+        # Specifically, outside the Spinner.run call method that's in
+        # _run_core.
+        #
+        # Because there are no hooks provided for this (although maybe there
+        # should be), we're going to use what's available to us. The return
+        # value of _get_log_fixture is used outside the Spinner run loop, and
+        # its details gathered.
+        return _SplitEliotLogs()
+
+    def _run_core(self):
+        """Template method that actually runs the suite."""
+        # Record the log starter *before* we run core, so that the
+        # _SplitEliotLogs fixture doesn't include it.
+        log.msg("--> Begin: %s <--" % (self.case.id()))
+        super(_AsyncRunner, self)._run_core()
+
+
+def async_runner(timeout):
+    """
+    Make a ``RunTest`` instance for asynchronous tests.
+
+    :param timedelta timeout: The maximum length of time that a test is allowed
+        to take.
+    """
+    # XXX: The acceptance tests (which were the first tests that we tried to
+    # migrate) aren't cleaning up after themselves even in the successful
+    # case. Use AsynchronousDeferredRunTestForBrokenTwisted, which loops the
+    # reactor a couple of times after the test is done.
+    async_factory = _AsyncRunner.make_factory(
+        timeout=timeout.total_seconds(),
+        suppress_twisted_logging=False,
+        store_twisted_logs=False,
+    )
+    return retry_flaky(async_factory)
+
+
+# By default, asynchronous tests are timed out after 2 minutes.
+DEFAULT_ASYNC_TIMEOUT = timedelta(minutes=2)
+
+
+def _test_skipped(case, result, exception):
+    result.addSkip(case, details={'reason': text_content(unicode(exception))})
+
+
+class AsyncTestCase(testtools.TestCase, _MktempMixin, _DeferredAssertionMixin):
+    """
+    Base class for asynchronous test cases.
+
+    :ivar reactor: The Twisted reactor that the test is being run in. Set by
+        ``async_runner`` and only available for the duration of the test.
+    """
+
+    run_tests_with = async_runner(timeout=DEFAULT_ASYNC_TIMEOUT)
+    # See comment on TestCase.skipException.
+    skipException = SkipTest
+
+    def assertFailure(self, deferred, exception):
+        """
+        ``twisted.trial.unittest.TestCase.assertFailure``-alike.
+
+        This is not completely compatible.  ``assert_fails_with`` should be
+        preferred for new code.
+        """
+        return assert_fails_with(deferred, exception)
+
+
+class _SplitEliotLogs(Fixture):
+    """
+    Split the Eliot logs out of Twisted logs.
+
+    Captures Twisted logs that contain Eliot logs as per
+    ``flocker._redirect_eliot_logs_for_trial``, and ensures these logs are
+    attached to a test case as details: one that contains the pure Twisted
+    logs without Eliot logs, and one that contains only the pretty printed
+    Eliot logs.
+    """
+
+    _ELIOT_LOG_DETAIL_NAME = 'twisted-eliot-log'
+
+    def _setUp(self):
+        twisted_logs = self.useFixture(CaptureTwistedLogs())
+        self._fix_twisted_logs(twisted_logs, twisted_logs.LOG_DETAIL_NAME)
+
+    def _fix_twisted_logs(self, detailed, detail_name):
+        """
+        Split the Eliot logs out of a Twisted log.
+
+        :param detailed: Object with ``getDetails`` where the original Twisted
+            logs are stored.
+        :param detail_name: Name of the Twisted log detail.
+        """
+        twisted_log = detailed.getDetails()[detail_name]
+        split_logs = [None]
+
+        def _get_split_logs():
+            # Memoize the split log so we don't iterate through it twice.
+            if split_logs[0] is None:
+                split_logs[0] = _split_map_maybe(
+                    extract_eliot_from_twisted_log,
+                    _iter_content_lines(twisted_log),
+                )
+            return split_logs[0]
+
+        # The trick here is that we can't iterate over the base detail yet.
+        # We can only use it inside the iter_bytes of the Content objects
+        # that we add. This is because the only time that we *know* the
+        # details are populated is when the details are evaluated. If we call
+        # it in _setUp(), the logs are empty. If we call it in cleanup, the
+        # detail is gone.
+
+        detailed.addDetail(
+            detail_name,
+            Content(UTF8_TEXT, lambda: _get_split_logs()[0]))
+
+        detailed.addDetail(
+            self._ELIOT_LOG_DETAIL_NAME,
+            Content(
+                UTF8_TEXT, lambda: _prettyformat_lines(_get_split_logs()[1])))
+
+
+def _split_map_maybe(function, sequence, marker=None):
+    """
+    Lazily map ``function`` over ``sequence``, yielding two streams:
+    ``(original, applied)``
+
+    :param function: Unary callable that might return ``marker``.
+    :param sequence: Iterable of objects that ``function`` will be applied to.
+    :param marker: Value returned by ``function`` when it cannot be
+        meaningfully applied to an object in ``sequence``.
+    :return: ``(original, applied)``, where ``original`` is an iterable of all
+        the elements, ``x``, in ``sequence`` where ``function(x)`` is
+        ``marker``, and ``applied`` is an iterable of all of the results of
+        ``function(x)`` that are not ``marker``.
+    """
+    annotated = ((x, function(x)) for x in sequence)
+    original, mapped = tee(annotated)
+    return (
+        (x for (x, y) in original if y is marker),
+        (y for (x, y) in mapped if y is not marker)
+    )
+
+
+def _prettyformat_lines(lines):
+    """
+    Pretty format lines of Eliot logs.
+    """
+    for line in lines:
+        data = json.loads(line)
+        yield pretty_format(data) + '\n'
+
+
+def extract_eliot_from_twisted_log(twisted_log_line):
+    """
+    Given a line from a Twisted log message, return the text of the Eliot log
+    message that is on that line.
+
+    If there is no Eliot message on that line, return ``None``.
+
+    :param str twisted_log_line: A line from a Twisted test.log.
+    :return: A logged eliot message without Twisted logging preamble, or
+        ``None``.
+    :rtype: unicode or ``NoneType``.
+    """
+    open_brace = twisted_log_line.find('{')
+    close_brace = twisted_log_line.rfind('}')
+    if open_brace == -1 or close_brace == -1:
+        return None
+    candidate = twisted_log_line[open_brace:close_brace + 1]
+    try:
+        fields = json.loads(candidate)
+    except (ValueError, TypeError):
+        return None
+    # Eliot lines always have these two keys.
+    if {"task_uuid", "timestamp"}.difference(fields):
+        return None
+    return candidate
+
+
+def _iter_content_lines(content):
+    """
+    Iterate over the lines that make up ``content``.
+
+    :param Content content: Arbitrary newline-separated content.
+    :yield: Newline-terminated bytestrings that make up the content.
+    """
+    return _iter_lines(content.iter_bytes(), '\n')
+
+
+def _iter_lines(byte_iter, line_separator):
+    """
+    Iterate over the lines that make up ``content``.
+
+    :param iter(bytes) byte_iter: An iterable of bytes.
+    :param bytes line_separator: The bytes that mark the end of a line.
+    :yield: Separator-terminated bytestrings.
+    """
+    # XXX: Someone must have written this before.
+    # XXX: Move this to flocker.common?
+    chunks = []
+    for data in byte_iter:
+        while data:
+            head, sep, data = data.partition(line_separator)
+            if not sep:
+                chunks.append(head)
+                break
+
+            chunks.append(head + sep)
+            yield ''.join(chunks)
+            chunks = []
+
+    if chunks:
+        yield ''.join(chunks)
+
+
+def _path_for_test_id(test_id, max_segment_length=32):
+    """
+    Get the temporary directory path for a test ID.
+
+    :param str test_id: A fully-qualified Python name. Must
+        have at least three components.
+    :param int max_segment_length: The longest that a path segment may be.
+    :return: A relative path to ``$module/$class/$method``.
+    """
+    if test_id.count('.') < 2:
+        raise ValueError(
+            "Must have at least three components (e.g. foo.bar.baz), got: %r"
+            % (test_id,))
+    return '/'.join(
+        segment[:max_segment_length] for segment in test_id.rsplit('.', 2))
+
+
+def _path_for_test(test):
+    """
+    Get the temporary directory path for a test.
+    """
+    return FilePath(_path_for_test_id(test.id()))
+
+
+def make_temporary_directory(base_path):
+    """
+    Create a temporary directory beneath ``base_path``.
+
+    It is the responsibility of the caller to delete the temporary directory.
+
+    :param FilePath base_path: Base directory for the temporary directory.
+        Will be created if it does not exist.
+    :return: The FilePath to a newly-created temporary directory, created
+        beneath the current working directory.
+    """
+    if not base_path.exists():
+        base_path.makedirs()
+    temp_dir = tempfile.mkdtemp(dir=base_path.path)
+    return FilePath(temp_dir)

--- a/lae_util/testtools/_base.py
+++ b/lae_util/testtools/_base.py
@@ -15,7 +15,7 @@
 """
 Base classes for unit tests.
 
-Originally ``flocker/testtools/__base.py``.
+Originally ``flocker/testtools/_base.py``.
 """
 
 from datetime import timedelta

--- a/lae_util/testtools/_base.py
+++ b/lae_util/testtools/_base.py
@@ -38,8 +38,27 @@ from twisted.python import log
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest
 
-from ..common import make_file
 from ._flaky import retry_flaky
+
+
+def make_file(path, content='', permissions=None):
+    """
+    Create a file with given content and permissions.
+
+    Don't use this for sensitive content, as the permissions are applied
+    *after* the data is written to the filesystem.
+
+    :param FilePath path: Path to create the file.
+    :param str content: Content to write to the file. If not specified,
+    :param int permissions: Unix file permissions to be passed to ``chmod``.
+
+    :return: ``path``, unmodified.
+    :rtype: :py:class:`twisted.python.filepath.FilePath`
+    """
+    path.setContent(content)
+    if permissions is not None:
+        path.chmod(permissions)
+    return path
 
 
 class _MktempMixin(object):

--- a/lae_util/testtools/_testhelpers.py
+++ b/lae_util/testtools/_testhelpers.py
@@ -1,0 +1,108 @@
+# Copyright 2014-2016 ClusterHQ
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Helpers for testing our test code.
+
+Only put stuff here that is specific to testing code about unit testing.
+
+Originally ``flocker/testtools/_testhelpers.py``.
+"""
+
+from hypothesis.strategies import sampled_from
+import unittest
+
+from testtools.matchers import (
+    AfterPreprocessing,
+    Equals,
+    MatchesStructure,
+)
+
+from ._base import TestCase
+
+
+base_test_cases = sampled_from([TestCase])
+
+
+def throw(exception):
+    """
+    Raise 'exception'.
+    """
+    raise exception
+
+
+def only_skips(tests_run, reasons):
+    """
+    Matches results that only had skips, and only for the given reasons.
+    """
+    return has_results(
+        tests_run=Equals(tests_run),
+        skipped=AfterPreprocessing(
+            lambda xs: list(unicode(x[1]) for x in xs),
+            Equals(reasons)),
+    )
+
+
+def has_results(errors=None, failures=None, skipped=None,
+                expected_failures=None, unexpected_successes=None,
+                tests_run=None):
+    """
+    Return a matcher on test results.
+
+    By default, will match a result that has no tests run.
+    """
+    if errors is None:
+        errors = Equals([])
+    if failures is None:
+        failures = Equals([])
+    if skipped is None:
+        skipped = Equals([])
+    if expected_failures is None:
+        expected_failures = Equals([])
+    if unexpected_successes is None:
+        unexpected_successes = Equals([])
+    if tests_run is None:
+        tests_run = Equals(0)
+    return MatchesStructure(
+        errors=errors,
+        failures=failures,
+        skipped=skipped,
+        expectedFailures=expected_failures,
+        unexpectedSuccesses=unexpected_successes,
+        testsRun=tests_run,
+    )
+
+
+def run_test(case):
+    """
+    Run a test and return its results.
+    """
+    # XXX: How many times have I written something like this?
+    result = unittest.TestResult()
+    case.run(result)
+    return result
+
+
+def make_test_case(base_case):
+    """
+    Make a single test that subclasses ``base_case`` and passes.
+
+    :param type base_case: A ``TestCase`` class.
+
+    :rtype: ``base_case``
+    """
+    class FooTests(base_case):
+        def test_something(self):
+            pass
+    return FooTests('test_something')

--- a/lae_util/testtools/matchers.py
+++ b/lae_util/testtools/matchers.py
@@ -1,0 +1,228 @@
+# Copyright 2014-2016 ClusterHQ
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Hamcrest-style matchers for testtools-based tests.
+"""
+
+from functools import partial
+import os
+
+from pyrsistent import PClass, field, pmap_field
+from testtools.content import Content
+from testtools.matchers import (
+    AfterPreprocessing,
+    DirExists,
+    FileExists,
+    MatchesAll,
+    PathExists,
+)
+
+
+def after(function, annotate=False):
+    """
+    Return a function that takes matcher factories and constructs a matcher
+    that applies ``function`` to candidate matchees.
+
+    Like ``AfterPreprocessing``, but operates on matcher factories (e.g.
+    constructors) rather than matcher objects.
+
+    :param (A -> B) function: Function to apply to matchees before attempting
+        to match.
+    :param bool annotate: Whether to include a message saying that ``function``
+        was applied in the error message.
+
+    :return: New matcher factory.
+    :rtype: (*a -> **kw -> Matcher[A]) -> (*args -> **kwargs -> Matcher[B])
+    """
+    # XXX: Probably should be part of upstream testtools.
+    def decorated(matcher):
+        def make_matcher(*args, **kwargs):
+            return AfterPreprocessing(
+                function, matcher(*args, **kwargs), annotate=annotate)
+
+        return make_matcher
+    return decorated
+
+
+class _Mismatch(PClass):
+    """
+    Immutable Mismatch that also stores the mismatched object.
+
+    :ivar mismatched: The object that failed to match.
+    """
+
+    # XXX: No direct tests.
+
+    # XXX: jml thinks the base testtools mismatch should be extended to
+    # include the mismatched object.
+
+    mismatched = field(object)
+    _description = field((str, unicode))
+    _details = pmap_field((str, unicode), Content)
+
+    def describe(self):
+        return self._description
+
+    def get_details(self):
+        return self._details
+
+
+def mismatch(mismatched, description, details):
+    """
+    Create an immutable Mismatch that also stores the mismatched object.
+    """
+    return _Mismatch(
+        mismatched=mismatched, _description=description, _details=details)
+
+
+def _adapt_mismatch(original, matchee):
+    """
+    If ``original`` doesn't already store ``matchee`` then return a new
+    one that has it stored.
+    """
+    # XXX: No direct tests.
+    marker = object()
+    if getattr(original, 'mismatched', marker) is marker:
+        return mismatch(matchee, original.describe(), original.get_details())
+    return original
+
+
+class _OnMismatch(PClass):
+    """
+    Decorate a matcher with a function that is run on mismatch.
+    """
+
+    _function = field()
+    _matcher = field()
+
+    def match(self, matchee):
+        """
+        Match if ``matchee`` matches the wrapped matcher.
+
+        If it does not match, apply the given function to the mismatch, first
+        ensuring that the mismatch has ``mismatched`` set.
+        """
+        mismatch = self._matcher.match(matchee)
+        if mismatch is None:
+            return
+        return self._function(_adapt_mismatch(mismatch, matchee))
+
+
+def OnMismatch(function, matcher):
+    """
+    Decorate ``matcher`` such that ``function`` is called on mismatches.
+    """
+    return _OnMismatch(_function=function, _matcher=matcher)
+
+
+def on_mismatch(function):
+    """
+    Return a function that maps matcher factories to new matcher factories,
+    such that the matchers returned by the new factories have ``function``
+    applied to any mismatch they receive.
+
+    :param (_Mismatch[A] -> _Mismatch[B]) function: Applied to any mismatch.
+    :return: A function that operates on matcher factories.
+    """
+    def decorated(matcher):
+        def make_matcher(*args, **kwargs):
+            return _OnMismatch(function, matcher(*args, **kwargs))
+
+        return make_matcher
+    return decorated
+
+
+def _filepath_to_path(filepath):
+    """
+    Convert FilePath to a regular path.
+    """
+    return filepath.path
+
+
+_on_filepath = after(_filepath_to_path)
+"""
+Lift regular path matchers to be FilePath matchers.
+"""
+
+
+path_exists = _on_filepath(PathExists)
+"""
+Match if a path exists on disk.
+
+For example::
+
+    self.assertThat('/bin/sh', path_exists())
+
+will probably pass on most Unix systems, but::
+
+    self.assertThat('/jml-is-awesome', path_exists())
+
+will most likely fail.
+"""
+
+
+dir_exists = _on_filepath(DirExists)
+"""
+Match if a directory exists on disk.
+"""
+
+
+file_exists = _on_filepath(FileExists)
+"""
+Match if a file exists on disk.
+"""
+
+
+def file_contents(matcher):
+    """
+    Match if a file's contents match ``matcher``.
+
+    For example::
+
+        self.assertThat(
+            FilePath('/foo/bar/baz'),
+            file_contents(Equals('hello world')))
+
+    Will match if there is a file ``/foo/bar/baz`` and if its contents are
+    exactly ``hello world``.
+    """
+
+    def get_content(file_path):
+        return file_path.getContent()
+
+    def content_mismatches(original):
+        return mismatch(
+            original.mismatched,
+            '%s has unexpected contents:\n%s' % (
+                original.mismatched.path, original.describe()),
+            original.get_details(),
+        )
+    # We don't use ``FileContains``, as that raises an IOError if the path is
+    # for an existing directory.
+    return MatchesAll(
+        file_exists(),
+        OnMismatch(
+            content_mismatches,
+            AfterPreprocessing(get_content, matcher, annotate=False)),
+        first_only=True,
+    )
+
+
+with_permissions = partial(
+    AfterPreprocessing,
+    lambda filepath: os.stat(filepath.path).st_mode & 07777)
+"""
+Match if path has the given permissions.
+"""

--- a/lae_util/testtools/strategies.py
+++ b/lae_util/testtools/strategies.py
@@ -1,0 +1,73 @@
+# Copyright 2014-2016 ClusterHQ
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Hypothesis strategies for QuickCheck-style testing.
+
+Originally ``flocker/testtools/strategies.py``.
+"""
+
+import string
+
+from hypothesis.strategies import integers, lists, text
+from twisted.python.filepath import FilePath
+
+
+path_segments = (
+    text().
+    filter(lambda x: '/' not in x).
+    map(lambda x: x.encode('utf8')).
+    filter(lambda x: '\0' not in x))
+"""
+Individual path segments.
+
+These are UTF-8 encoded segments that contain neither '/' nor NULL.
+
+e.g. 'foo', 'rc.local'.
+"""
+
+
+paths = lists(path_segments).map(lambda ps: FilePath('/'.join(ps)))
+"""
+Paths
+
+e.g. ``FilePath('/usr/local')``, ``FilePath('foo/bar/bar')``.
+"""
+
+
+_identifier_characters = string.ascii_letters + string.digits + '_'
+
+
+identifiers = text(
+    average_size=20, min_size=1, alphabet=_identifier_characters)
+"""
+Python identifiers.
+
+e.g. ``Foo``, ``bar``.
+"""
+
+
+fqpns = lists(
+    identifiers, min_size=1, average_size=5).map(lambda xs: '.'.join(xs))
+"""
+Fully-qualified Python names.
+
+e.g. ``twisted.internet.defer.Deferred``, ``foo.bar.baz_qux``.
+"""
+
+
+permissions = integers(min_value=0, max_value=07777)
+"""
+Unix file permissions.
+"""

--- a/lae_util/testtools/test/__init__.py
+++ b/lae_util/testtools/test/__init__.py
@@ -1,0 +1,5 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Tests for testtools.
+"""

--- a/lae_util/testtools/test/test_base.py
+++ b/lae_util/testtools/test/test_base.py
@@ -1,0 +1,514 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Tests for flocker base test cases.
+"""
+
+import errno
+import os
+import shutil
+from datetime import timedelta
+import unittest
+
+from eliot import MessageType, fields
+from fixtures import Fixture, MonkeyPatch
+from hypothesis import assume, given
+from hypothesis.strategies import binary, integers, lists, text
+
+# Use testtools' TestCase for most of these tests so that bugs in our base test
+# case classes don't invalidate the tests for those classes.
+from testtools import TestCase as TesttoolsTestCase
+from testtools import TestResult
+from testtools.matchers import (
+    AllMatch,
+    AfterPreprocessing,
+    Annotate,
+    Contains,
+    ContainsDict,
+    DirExists,
+    HasLength,
+    EndsWith,
+    Equals,
+    FileContains,
+    Is,
+    Matcher,
+    MatchesAll,
+    MatchesAny,
+    MatchesDict,
+    MatchesListwise,
+    MatchesRegex,
+    LessThan,
+    Not,
+    PathExists,
+    StartsWith,
+    IsInstance,
+)
+from twisted.internet.defer import Deferred, succeed, fail
+from twisted.python.filepath import FilePath
+from twisted.python.failure import Failure
+
+from .. import CustomException, TestCase, async_runner
+from .._base import (
+    _SplitEliotLogs,
+    _iter_lines,
+    _path_for_test_id,
+    extract_eliot_from_twisted_log,
+)
+from ..matchers import dir_exists, file_contents
+from ..strategies import fqpns
+from .._testhelpers import (
+    base_test_cases,
+    has_results,
+    make_test_case,
+    only_skips,
+    run_test,
+)
+
+
+class BaseTestCaseTests(TesttoolsTestCase):
+    """
+    Tests for our base test cases.
+    """
+
+    @given(base_test_cases, text(average_size=30))
+    def test_trial_skip_exception(self, base_test_case, reason):
+        """
+        If tests raise the ``SkipTest`` exported by Trial, then that's
+        recorded as a skip.
+        """
+
+        class SkippingTest(base_test_case):
+            def test_skip(self):
+                raise unittest.SkipTest(reason)
+
+        test = SkippingTest('test_skip')
+        result = run_test(test)
+        self.assertThat(result, only_skips(1, [reason]))
+
+    @given(base_test_cases.map(make_test_case))
+    def test_mktemp_doesnt_exist(self, test):
+        """
+        ``mktemp`` returns a path that doesn't exist inside a directory that
+        does.
+        """
+        temp_path = FilePath(test.mktemp())
+        self.addCleanup(_remove_dir, temp_path.parent())
+
+        self.expectThat(temp_path.parent().path, DirExists())
+        self.expectThat(temp_path.path, Not(PathExists()))
+        self.assertThat(temp_path, BelowPath(FilePath(os.getcwd())))
+
+    @given(base_test_cases)
+    def test_mktemp_not_deleted(self, base_test_case):
+        """
+        ``mktemp`` returns a path that's not deleted after the test is run.
+        """
+        created_files = []
+
+        class SomeTest(base_test_case):
+            def test_create_file(self):
+                path = self.mktemp()
+                created_files.append(path)
+                open(path, 'w').write('hello')
+
+        run_test(SomeTest('test_create_file'))
+        [path] = created_files
+        self.addCleanup(os.unlink, path)
+        self.assertThat(path, FileContains('hello'))
+
+    @given(base_test_cases.map(make_test_case))
+    def test_make_temporary_path_doesnt_exist(self, test):
+        """
+        ``make_temporary_path`` returns a path that doesn't exist inside a
+        directory that does.
+        """
+        temp_path = test.make_temporary_path()
+        self.addCleanup(_remove_dir, temp_path.parent())
+
+        self.expectThat(temp_path.parent().path, DirExists())
+        self.expectThat(temp_path.path, Not(PathExists()))
+        self.assertThat(temp_path, BelowPath(FilePath(os.getcwd())))
+
+    @given(base_test_cases)
+    def test_make_temporary_path_not_deleted(self, base_test_case):
+        """
+        ``make_temporary_path`` returns a path that's not deleted after the
+        test is run.
+        """
+        created_files = []
+
+        class SomeTest(base_test_case):
+            def test_create_file(self):
+                path = self.make_temporary_path()
+                created_files.append(path)
+                path.setContent('hello')
+
+        run_test(SomeTest('test_create_file'))
+        [path] = created_files
+        self.addCleanup(path.remove)
+        self.assertThat(path.path, FileContains('hello'))
+
+    @given(base_test_cases.map(make_test_case))
+    def test_make_temporary_directory_exists(self, test):
+        """
+        ``make_temporary_directory`` returns a path to a directory.
+        """
+        temp_dir = test.make_temporary_directory()
+        self.addCleanup(_remove_dir, temp_dir)
+        self.assertThat(temp_dir, dir_exists())
+
+    @given(base_test_cases.map(make_test_case), binary(average_size=20))
+    def test_make_temporary_file_with_content(self, test, content):
+        """
+        ``make_temporary_file`` returns a path to an existing file.
+        """
+        temp_file = test.make_temporary_file(content)
+        self.addCleanup(temp_file.remove)
+        self.assertThat(temp_file, file_contents(Equals(content)))
+
+    @given(base_test_cases.map(make_test_case))
+    def test_make_temporary_file(self, test):
+        """
+        ``make_temporary_file`` returns a path to an existing file. If no
+        content is provided, defaults to an empty file.
+        """
+        temp_file = test.make_temporary_file()
+        self.addCleanup(temp_file.remove)
+        self.assertThat(temp_file, file_contents(Equals('')))
+
+    @given(base_test_cases.map(make_test_case))
+    def test_run_twice(self, test):
+        """
+        Tests can be run twice without errors.
+
+        This is being fixed upstream at
+        https://github.com/testing-cabal/testtools/pull/165/, and this test
+        coverage is inadequate for a thorough fix. However, this will be
+        enough to let us use ``trial -u`` (see FLOC-3462).
+        """
+        result = TestResult()
+        test.run(result)
+        test.run(result)
+        self.assertThat(
+            result, has_results(
+                tests_run=Equals(2),
+            )
+        )
+
+    @given(base_test_cases)
+    def test_attaches_twisted_log(self, base_test_case):
+        """
+        Flocker base test cases attach the Twisted log as a detail.
+        """
+        # XXX: If debugging is enabled (either by setting this to True or by
+        # removing this line and running --debug-stacktraces, then the log
+        # fixtures in this test are empty. However, if we run a failing test
+        # manually, the logs appear in the details. Not sure what's going on,
+        # so disabling debugging for now.
+        self.useFixture(DebugTwisted(False))
+
+        class SomeTest(base_test_case):
+            def test_something(self):
+                from twisted.python import log
+                log.msg('foo')
+
+        test = SomeTest('test_something')
+        result = TestResult()
+        test.run(result)
+        self.expectThat(result, has_results(tests_run=Equals(1)))
+        self.assertThat(
+            test.getDetails(),
+            ContainsDict({
+                'twisted-log': match_text_content(MatchesRegex(
+                    r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[+-]\d{4} \[-\] foo'
+                )),
+            }))
+
+    @given(base_test_cases)
+    def test_separate_eliot_log(self, base_test_case):
+        """
+        Flocker base test cases attach the eliot log as a detail separate from
+        the Twisted log.
+        """
+        # XXX: If debugging is enabled (either by setting this to True or by
+        # removing this line and running --debug-stacktraces, then the log
+        # fixtures in this test are empty. However, if we run a failing test
+        # manually, the logs appear in the details. Not sure what's going on,
+        # so disabling debugging for now.
+        self.useFixture(DebugTwisted(False))
+        message_type = MessageType(u'foo', fields(name=str), u'test message')
+
+        class SomeTest(base_test_case):
+            def test_something(self):
+                from twisted.python import log
+                log.msg('foo')
+                message_type(name='qux').write()
+
+        test = SomeTest('test_something')
+        result = TestResult()
+        test.run(result)
+        self.expectThat(result, has_results(tests_run=Equals(1)))
+        self.assertThat(
+            test.getDetails(),
+            MatchesDict({
+                'twisted-log': match_text_content(MatchesRegex(
+                    r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[+-]\d{4} \[-\] foo'
+                )),
+                _SplitEliotLogs._ELIOT_LOG_DETAIL_NAME: match_text_content(
+                    Contains("  message_type: 'foo'\n"
+                             "  name: 'qux'\n")
+                ),
+            }))
+
+
+class DebugTwisted(Fixture):
+    """
+    Set debugging for various Twisted things.
+    """
+
+    def __init__(self, debug):
+        """
+        Set debugging for Deferreds and DelayedCalls.
+
+        :param bool debug: If True, enable debugging. If False, disable it.
+        """
+        super(DebugTwisted, self).__init__()
+        self._debug_setting = debug
+
+    def _setUp(self):
+        self.useFixture(
+            MonkeyPatch('twisted.internet.defer.Deferred.debug',
+                        self._debug_setting))
+        self.useFixture(
+            MonkeyPatch('twisted.internet.base.DelayedCall.debug',
+                        self._debug_setting))
+
+
+def match_text_content(matcher):
+    """
+    Match the text of a ``Content`` instance.
+    """
+    return AfterPreprocessing(lambda content: content.as_text(), matcher)
+
+
+class IterLinesTests(TesttoolsTestCase):
+    """
+    Tests for ``_iter_lines``.
+    """
+
+    @given(lists(binary()), binary(min_size=1))
+    def test_preserves_data(self, data, separator):
+        """
+        Splitting into lines loses no data.
+        """
+        observed = _iter_lines(iter(data), separator)
+        self.assertThat(''.join(observed), Equals(''.join(data)))
+
+    @given(lists(binary()), binary(min_size=1))
+    def test_separator_terminates(self, data, separator):
+        """
+        After splitting into lines, each line ends with the separator.
+        """
+        # Make sure data ends with the separator.
+        data.append(separator)
+        observed = list(_iter_lines(iter(data), separator))
+        self.assertThat(observed, AllMatch(EndsWith(separator)))
+
+    @given(lists(binary(min_size=1), min_size=1), binary(min_size=1))
+    def test_nonterminated_line(self, data, separator):
+        """
+        If the input data does not end with a separator, then every line ends
+        with a separator *except* the last line.
+        """
+        # Except when the data *ends* with the separator
+        # E.g. data = '\x00'; separator = '\x00'
+        assume(not b''.join(data).endswith(separator))
+        observed = list(_iter_lines(iter(data), separator))
+        self.expectThat(observed[:-1], AllMatch(EndsWith(separator)))
+        self.assertThat(observed[-1], Not(EndsWith(separator)))
+
+
+class ExtractEliotFromTwistedLogTests(TesttoolsTestCase):
+    """
+    Tests for ``extract_eliot_from_twisted_log``.
+    """
+
+    def test_twisted_line(self):
+        """
+        When given a line logged by Twisted, extract_eliot_from_twisted_log
+        returns ``None``.
+        """
+        line = '2015-12-11 11:59:48+0000 [-] foo\n'
+        self.assertThat(extract_eliot_from_twisted_log(line), Is(None))
+
+    def test_eliot_line(self):
+        """
+        When given a line logged by Eliot, extract_eliot_from_twisted_log
+        returns the bytes that were logged by Eliot.
+        """
+        logged_line = (
+            '2015-12-11 11:59:48+0000 [-] ELIOT: '
+            '{"timestamp": 1449835188.575052, '
+            '"task_uuid": "6c579710-1b95-4604-b5a1-36b56f8ceb53", '
+            '"message_type": "foo", '
+            '"name": "qux", '
+            '"task_level": [1]}\n'
+        )
+        expected = (
+            '{"timestamp": 1449835188.575052, '
+            '"task_uuid": "6c579710-1b95-4604-b5a1-36b56f8ceb53", '
+            '"message_type": "foo", '
+            '"name": "qux", '
+            '"task_level": [1]}'
+        )
+        self.assertThat(
+            extract_eliot_from_twisted_log(logged_line), Equals(expected))
+
+    def test_line_with_substructure(self):
+        """
+        When given a line that has JSON substructures,
+        extract_eliot_from_twisted_log returns the bytes that were logged by
+        Eliot.
+        """
+        logged_line = (
+            '{"timestamp": 1449835188.575052, '
+            '"task_uuid": "6c579710-1b95-4604-b5a1-36b56f8ceb53", '
+            '"message_type": "foo", '
+            '"name": "qux", '
+            '"subobj": {"a": "cat"},'
+            '"task_level": [1]} \n'
+        )
+        expected = (
+            '{"timestamp": 1449835188.575052, '
+            '"task_uuid": "6c579710-1b95-4604-b5a1-36b56f8ceb53", '
+            '"message_type": "foo", '
+            '"name": "qux", '
+            '"subobj": {"a": "cat"},'
+            '"task_level": [1]}'
+        )
+        self.assertThat(
+            extract_eliot_from_twisted_log(logged_line), Equals(expected))
+
+    def test_line_with_invalid_json(self):
+        """
+        When given an incomplete line that has the beginning of a JSON line,
+        extract_eliot_from_twisted_log returns None.
+        """
+        logged_line = (
+            'prefix ELIOT: {"timestamp": 1449835188.575052, '
+            '"task_uuid": "6c579710-1b95-4604-b5a1-36b56f8ceb53", '
+            '"message_type": "foo", '
+            '"name": "qu'
+        )
+        self.assertThat(
+            extract_eliot_from_twisted_log(logged_line), Is(None))
+
+
+class MakeTemporaryTests(TesttoolsTestCase):
+    """
+    Tests for code for making temporary files and directories for tests.
+    """
+
+    @given(test_id=fqpns, max_length=integers(min_value=1, max_value=64))
+    def test_directory_for_test(self, test_id, max_length):
+        """
+        _path_for_test_id returns a relative path of $module/$class/$method for
+        the given test id.
+        """
+        assume(test_id.count('.') > 1)
+        path = _path_for_test_id(test_id, max_length)
+        self.expectThat(path, Not(StartsWith('/')))
+        segments = path.split('/')
+        self.expectThat(segments, HasLength(3))
+        self.assertThat(
+            segments,
+            AllMatch(
+                AfterPreprocessing(
+                    len, MatchesAny(
+                        LessThan(max_length),
+                        Equals(max_length)
+                    )
+                )
+            )
+        )
+
+    @given(test_id=fqpns)
+    def test_too_short_test_id(self, test_id):
+        """
+        If the given test id is has too few segments, raise an error.
+        """
+        assume(test_id.count('.') < 2)
+        self.assertRaises(ValueError, _path_for_test_id, test_id)
+
+
+def _remove_dir(path):
+    """
+    Safely remove the directory 'path'.
+    """
+    try:
+        shutil.rmtree(path.path)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+
+
+class BelowPath(Matcher):
+    """
+    Match if the given path is a child (or grandchild, etc.) of the specified
+    parent.
+    """
+
+    def __init__(self, parent):
+        """
+        Construct a ``BelowPath`` that will successfully match for any child
+        of ``parent``.
+
+        :param FilePath parent: The parent path. Any path beneath this will
+            match.
+        """
+        self._parent = parent
+
+    def match(self, child):
+        """
+        Assert ``child`` is beneath the core path.
+        """
+        return Annotate(
+            "%s in not beneath %s" % (child, self._parent),
+            Contains(self._parent)).match(child.parents())
+
+
+class ResultOfAssertionsTests(TestCase):
+    """
+    Bare minimum of testing for the Deferred result-related assertions borrowed
+    from Twisted.
+
+    These tests aren't more thorough because we don't implement them in
+    Flocker.  We just want to verify we've glued in the Twisted implementation
+    successfully.
+    """
+    def test_assertNoResult(self):
+        """
+        ``flocker.testtools.TestCase.assertNoResult`` works like
+        ``twisted.trial.unittest.SynchronousTestCase.assertNoResult``.
+        """
+        self.assertNoResult(Deferred())
+
+    def test_successResultOf(self):
+        """
+        ``flocker.testtools.TestCase.successResultOf`` works like
+        ``twisted.trial.unittest.SynchronousTestCase.successResultOf``.
+        """
+        self.assertThat(
+            self.successResultOf(succeed(3)),
+            Equals(3),
+        )
+
+    def test_failureResultOf(self):
+        """
+        ``flocker.testtools.TestCase.failureResultOf`` works like
+        ``twisted.trial.unittest.SynchronousTestCase.failureResultOf``.
+        """
+        self.assertThat(
+            self.failureResultOf(fail(CustomException()), CustomException),
+            IsInstance(Failure),
+        )

--- a/lae_util/testtools/test/test_base.py
+++ b/lae_util/testtools/test/test_base.py
@@ -47,7 +47,7 @@ from twisted.internet.defer import Deferred, succeed, fail
 from twisted.python.filepath import FilePath
 from twisted.python.failure import Failure
 
-from .. import CustomException, TestCase, async_runner
+from .. import CustomException, TestCase
 from .._base import (
     _SplitEliotLogs,
     _iter_lines,

--- a/lae_util/testtools/test/test_matchers.py
+++ b/lae_util/testtools/test/test_matchers.py
@@ -1,0 +1,212 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+from hypothesis import assume, given
+from hypothesis.strategies import binary
+from testtools.matchers import (
+    AfterPreprocessing,
+    DirExists,
+    Equals,
+    FileExists,
+    Is,
+    Not,
+    PathExists,
+)
+
+from .. import TestCase
+from ..strategies import paths
+from ..matchers import (
+    dir_exists,
+    file_contents,
+    file_exists,
+    path_exists,
+)
+
+
+def is_equivalent_mismatch(expected):
+    """
+    Matches another mismatch.
+
+    :param Optional[Mismatch] expected: If None, then match None,
+        otherwise, match a mismatch that has the same description and details.
+    :rtype: Matcher
+    """
+    def to_dict(mismatch):
+        return {
+            'details': mismatch.get_details(),
+            'description': mismatch.describe(),
+        }
+    if expected is None:
+        return Is(None)
+    # XXX: This should really be a standard combinator.
+    return AfterPreprocessing(
+        to_dict, Equals(to_dict(expected)), annotate=False)
+
+
+class PathExistsTests(TestCase):
+    """
+    Tests for :py:func:`path_exists`.
+    """
+
+    def test_does_not_exist(self):
+        """
+        If the path does not exist, path_exists does not match.
+        """
+        path = self.make_temporary_path()
+        self.assertThat(path, Not(path_exists()))
+
+    def test_file_exists(self):
+        """
+        If there is a file at path, path_exists matches.
+        """
+        path = self.make_temporary_path()
+        path.setContent('foo')
+        self.assertThat(path, path_exists())
+
+    def test_dir_exists(self):
+        """
+        If there is a directory at path, path_exists matches.
+        """
+        path = self.make_temporary_path()
+        path.makedirs()
+        self.assertThat(path, path_exists())
+
+    @given(paths)
+    def test_equivalent_to_standard_path_exists(self, path):
+        """
+        path_exists is to FilePaths what PathExists is to normal paths.
+        """
+        self.assertThat(
+            path_exists().match(path),
+            is_equivalent_mismatch(PathExists().match(path.path)),
+        )
+
+
+class DirExistsTests(TestCase):
+    """
+    Tests for :py:func:`dir_exists`.
+    """
+
+    def test_does_not_exist(self):
+        """
+        If the path does not exist, dir_exists does not match.
+        """
+        path = self.make_temporary_path()
+        self.assertThat(path, Not(dir_exists()))
+
+    def test_file_exists(self):
+        """
+        If there is a file at path, dir_exists does not match.
+        """
+        path = self.make_temporary_path()
+        path.setContent('foo')
+        self.assertThat(path, Not(dir_exists()))
+
+    def test_dir_exists(self):
+        """
+        If there is a directory at path, dir_exists matches.
+        """
+        path = self.make_temporary_path()
+        path.makedirs()
+        self.assertThat(path, dir_exists())
+
+    @given(paths)
+    def test_equivalent_to_standard_dir_exists(self, path):
+        """
+        dir_exists is to FilePaths what DirExists is to normal paths.
+        """
+        self.assertThat(
+            dir_exists().match(path),
+            is_equivalent_mismatch(DirExists().match(path.path)),
+        )
+
+
+class FileExistsTests(TestCase):
+    """
+    Tests for :py:func:`file_exists`.
+    """
+
+    def test_does_not_exist(self):
+        """
+        If the path does not exist, file_exists does not match.
+        """
+        path = self.make_temporary_path()
+        self.assertThat(path, Not(file_exists()))
+
+    def test_file_exists(self):
+        """
+        If there is a file at path, file_exists matches.
+        """
+        path = self.make_temporary_path()
+        path.setContent('foo')
+        self.assertThat(path, file_exists())
+
+    def test_dir_exists(self):
+        """
+        If there is a directory at path, file_exists does not match.
+        """
+        path = self.make_temporary_directory()
+        self.assertThat(path, Not(file_exists()))
+
+    @given(paths)
+    def test_equivalent_to_standard_file_exists(self, path):
+        """
+        file_exists is to FilePaths what FileExists is to normal paths.
+        """
+        self.assertThat(
+            file_exists().match(path),
+            is_equivalent_mismatch(FileExists().match(path.path)),
+        )
+
+
+class FileContainsTests(TestCase):
+    """
+    Tests for :py:func:`file_contains`.
+    """
+
+    def test_does_not_exist(self):
+        """
+        If the path does not exist, file_contains does not match.
+        """
+        path = self.make_temporary_path()
+        arbitrary_matcher = Is(None)
+        mismatch = file_contents(arbitrary_matcher).match(path)
+        self.assertThat(
+            mismatch.describe(), Equals('%s does not exist.' % (path.path)))
+
+    def test_directory(self):
+        """
+        If the path is a directory, file_contains does not match.
+        """
+        path = self.make_temporary_directory()
+        arbitrary_matcher = Is(None)
+        mismatch = file_contents(arbitrary_matcher).match(path)
+        self.assertThat(
+            mismatch.describe(), Equals('%s is not a file.' % (path.path)))
+
+    @given(observed=binary(average_size=10), expected=binary(average_size=10))
+    def test_file_exists_content_mismatch(self, observed, expected):
+        """
+        If the file exists, the content is matched against the given matcher.
+        If it mismatches, the message includes both the filename and the
+        message from the underlying matcher.
+        """
+        assume(observed != expected)
+        matcher = Equals(expected)
+        path = self.make_temporary_path()
+        path.setContent(observed)
+        mismatch = file_contents(matcher).match(path)
+        self.assertThat(
+            mismatch.describe(),
+            Equals(
+                '%s has unexpected contents:\n%s' %
+                (path.path, matcher.match(observed).describe())))
+
+    @given(content=binary(average_size=10))
+    def test_file_exists_content_match(self, content):
+        """
+        If the file exists, the content is matched against the given matcher.
+        If it matches, then the overall matcher also matches.
+        """
+        path = self.make_temporary_path()
+        path.setContent(content)
+        self.assertThat(path, file_contents(Equals(content)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ simplejson
 twisted
 service_identity
 attrs==16.3.0
+eliot==0.11.0
+bitmath==1.3.1.2
 
 txAWS==0.2.1.post5
 


### PR DESCRIPTION
Fixes #453 

This is a very large PR.  Most of the changes are in `lae_util` and represent the import of some code from another project.  The functionality includes a retry helper that makes the lae-specific part of this fix quite simple (though some additional refactoring was required to make the changes testable).

The imported code is trimmed down to remove some of the obviously irrelevant portions.  Other pieces which are not actually necessary to fix this issue have been left in place because it was easier than deleting them and they may come in useful in the future.