### PR TITLE
MemoryAgent and a related helper.

### DIFF
--- a/lae_util/memoryagent.py
+++ b/lae_util/memoryagent.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-In-memory `IAgent` implementation.
+In-memory ``IAgent`` implementation.
 
 Originally from ``flocker/restapi/testtools.py``.
 """

--- a/lae_util/memoryagent.py
+++ b/lae_util/memoryagent.py
@@ -1,0 +1,340 @@
+# Copyright 2014-2016 ClusterHQ
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+In-memory `IAgent` implementation.
+
+Originally from ``flocker/restapi/testtools.py``.
+"""
+
+from io import BytesIO
+from itertools import count
+
+from zope.interface import implementer
+
+from twisted.internet.interfaces import IPushProducer
+from twisted.internet.defer import Deferred, succeed
+from twisted.internet.address import IPv4Address
+from twisted.python.log import err
+from twisted.web.client import ResponseDone
+from twisted.web.server import NOT_DONE_YET, Request
+from twisted.web.http import HTTPChannel, urlparse, unquote
+from twisted.web.iweb import IAgent, IResponse
+from twisted.web.http_headers import Headers
+from twisted.web.resource import getChildForRequest
+from twisted.test.proto_helpers import StringTransport
+from twisted.python.failure import Failure
+
+
+class EventChannel(object):
+    """
+    An L{EventChannel} provides one-to-many event publishing in a
+    re-usable container.
+
+    Any number of parties may subscribe to an event channel to receive
+    the very next event published over it.  A subscription is a
+    L{Deferred} which will get the next result and is then no longer
+    associated with the L{EventChannel} in any way.
+
+    Future events can be received by re-subscribing to the channel.
+
+    @ivar _subscriptions: A L{list} of L{Deferred} instances which are waiting
+        for the next event.
+    """
+    def __init__(self):
+        self._subscriptions = []
+
+    def _itersubscriptions(self):
+        """
+        Return an iterator over all current subscriptions after
+        resetting internal subscription state to forget about all of
+        them.
+        """
+        subscriptions = self._subscriptions[:]
+        del self._subscriptions[:]
+        return iter(subscriptions)
+
+    def callback(self, value):
+        """
+        Supply a success value for the next event which will be published now.
+        """
+        for subscr in self._itersubscriptions():
+            subscr.callback(value)
+
+    def errback(self, reason=None):
+        """
+        Supply a failure value for the next event which will be published now.
+        """
+        for subscr in self._itersubscriptions():
+            subscr.errback(reason)
+
+    def subscribe(self):
+        """
+        Get a L{Deferred} which will fire with the next event on this channel.
+
+        @rtype: L{Deferred}
+        """
+        d = Deferred(canceller=self._subscriptions.remove)
+        self._subscriptions.append(d)
+        return d
+
+
+_dummyRequestCounter = iter(count())
+
+
+def dummyRequest(method, path, headers, body=b""):
+    """
+    Construct a new dummy L{IRequest} provider.
+
+    @param method: The HTTP method of the request.  For example, C{b"GET"}.
+    @type method: L{bytes}
+
+    @param path: The encoded path part of the URI of the request.  For example,
+        C{b"/foo"}.
+    @type path: L{bytes}
+
+    @param headers: The headers of the request.
+    @type headers: L{Headers}
+
+    @param body: The bytes that make up the request body.
+    @type body: L{bytes}
+
+    @return: A L{IRequest} which can be used to render an L{IResource} using
+        only in-memory data structures.
+    """
+    parsed = urlparse(path)
+    if parsed.query:
+        # Oops, dropped params.  Good thing no one cares.
+        new_path = parsed.path + "?" + parsed.query
+    else:
+        new_path = parsed.path
+    return _DummyRequest(
+        next(_dummyRequestCounter),
+        method, new_path, headers, body)
+
+
+def render(resource, request):
+    """
+    Render an L{IResource} using a particular L{IRequest}.
+
+    @raise ValueError: If L{IResource.render} returns an unsupported value.
+
+    @return: A L{Deferred} that fires with C{None} when the response has been
+        completely rendered.
+    """
+    result = resource.render(request)
+    if isinstance(result, bytes):
+        request.write(result)
+        request.finish()
+        return succeed(None)
+    elif result is NOT_DONE_YET:
+        if request._finished:
+            return succeed(None)
+        else:
+            return request.notifyFinish()
+    else:
+        raise ValueError("Unexpected return value: %r" % (result,))
+
+
+class _DummyRequest(Request):
+
+    # Request has code and code_message attributes.  They're not part of
+    # IRequest.  A bunch of existing code written against _DummyRequest used
+    # the _code and _message attributes previously provided by _DummyRequest
+    # (at least those names look like they're not part of the interface).
+    # Preserve those attributes here but avoid re-implementing setResponseCode
+    # or duplicating the state Request is keeping.
+    @property
+    def _code(self):
+        return self.code
+
+    @property
+    def _message(self):
+        return self.code_message
+
+    def __init__(self, counter, method, path, headers, content):
+
+        channel = HTTPChannel()
+        host = IPv4Address(b"TCP", b"127.0.0.1", 80)
+        channel.makeConnection(StringTransport(hostAddress=host))
+
+        Request.__init__(self, channel, False)
+
+        # An extra attribute for identifying this fake request
+        self._counter = counter
+
+        # Attributes a Request is supposed to have but we have to set ourselves
+        # because the base class mixes together too much other logic with the
+        # code that sets them.
+        self.prepath = []
+        self.requestHeaders = headers
+        self.content = BytesIO(content)
+
+        self.requestReceived(method, path, b"HTTP/1.1")
+
+        # requestReceived initializes the path attribute for us (but not
+        # postpath).
+        self.postpath = list(map(unquote, self.path[1:].split(b'/')))
+
+        # Our own notifyFinish / finish state because the inherited
+        # implementation wants to write confusing stuff to the transport when
+        # the request gets finished.
+        self._finished = False
+        self._finishedChannel = EventChannel()
+
+        # Our own state for the response body so we don't have to dig it out of
+        # the transport.
+        self._responseBody = b""
+
+    def process(self):
+        """
+        Don't do any processing.  Override the inherited implementation so it
+        doesn't do any, either.
+        """
+
+    def finish(self):
+        self._finished = True
+        self._finishedChannel.callback(None)
+
+    def notifyFinish(self):
+        return self._finishedChannel.subscribe()
+
+    # Not part of the interface but called by DeferredResource, used by
+    # twisted.web.guard (therefore important to us)
+    def processingFailed(self, reason):
+        err(reason, "Processing _DummyRequest %d failed" % (self._counter,))
+
+    def write(self, data):
+        self._responseBody += data
+
+    def render(self, resource):
+        # TODO: Required by twisted.web.guard but not part of IRequest ???
+        render(resource, self)
+
+
+def asResponse(request):
+    """
+    Extract the response data stored on a request and create a real response
+    object from it.
+
+    @param request: A L{_DummyRequest} that has been rendered.
+
+    @return: An L{IResponse} provider carrying all of the response information
+        that was rendered onto C{request}.
+    """
+    return _MemoryResponse(
+        b"HTTP/1.1", request.code, request.code_message,
+        request.responseHeaders, None, None,
+        request._responseBody)
+
+
+@implementer(IResponse)
+class _MemoryResponse(object):
+    """
+    An entirely in-memory response to an HTTP request. This is not tested
+    because it should be moved to Twisted.
+    """
+    def __init__(self, version, code, phrase, headers, request,
+                 previousResponse, responseBody):
+        """
+        @see: L{IResponse}
+
+        @param responseBody: The body of the response.
+        @type responseBody: L{bytes}
+        """
+        self.version = version
+        self.code = code
+        self.phrase = phrase
+        self.headers = headers
+        self.request = request
+        self.length = len(responseBody)
+        self._responseBody = responseBody
+        self.setPreviousResponse(previousResponse)
+
+    def deliverBody(self, protocol):
+        """
+        Immediately deliver the entire response body to C{protocol}.
+        """
+        protocol.makeConnection(_StubProducer())
+        protocol.dataReceived(self._responseBody)
+        protocol.connectionLost(Failure(ResponseDone()))
+
+    def setPreviousResponse(self, response):
+        self.previousResponse = response
+
+
+@implementer(IPushProducer)
+class _StubProducer(object):
+    """
+    A do-nothing producer that L{_MemoryResponse} can use while
+    delivering response bodies.
+    """
+    def pauseProducing(self):
+        pass
+
+    def resumeProducing(self):
+        pass
+
+    def stopProducing(self):
+        pass
+
+
+@implementer(IAgent)
+class MemoryAgent(object):
+    """
+    L{MemoryAgent} generates responses to requests by rendering an
+    L{IResource} using those requests.
+
+    @ivar resource: The root resource from which traversal for request
+        dispatching/response starts.
+    @type resource: L{IResource} provider
+    """
+    def __init__(self, resource):
+        self.resource = resource
+
+    def request(self, method, url, headers=None, bodyProducer=None):
+        """
+        Find the child of C{self.resource} for the given request and
+        render it to generate a response.
+        """
+        if headers is None:
+            headers = Headers()
+
+        # Twisted Web server only supports dispatching requests after reading
+        # the entire request body into memory.
+        content = BytesIO()
+        if bodyProducer is None:
+            reading = succeed(None)
+        else:
+            reading = bodyProducer.startProducing(content)
+
+        def finishedReading(ignored):
+            request = dummyRequest(method, url, headers, content.getvalue())
+            resource = getChildForRequest(self.resource, request)
+            d = render(resource, request)
+            d.addCallback(lambda ignored: request)
+            return d
+        rendering = reading.addCallback(finishedReading)
+
+        def rendered(request):
+            return _MemoryResponse(
+                (b"HTTP", 1, 1),
+                request._code,
+                request._message,
+                request.responseHeaders,
+                request,
+                None,
+                request._responseBody)
+        rendering.addCallback(rendered)
+        return reading

--- a/lae_util/test/test_memoryagent.py
+++ b/lae_util/test/test_memoryagent.py
@@ -197,7 +197,7 @@ class MemoryAgentTests(TestCase):
                 for v in args[k]
             ))
         agent = MemoryAgent(parent)
-        response = self.successResultOf(
+        self.successResultOf(
             agent.request(method, path, headers, producer)
         )
 

--- a/lae_util/test/test_memoryagent.py
+++ b/lae_util/test/test_memoryagent.py
@@ -1,0 +1,212 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
+"""
+Tests for ``lae_automation.memoryagent``.
+"""
+
+from io import BytesIO
+from urllib import quote
+
+from hypothesis import given
+from hypothesis.strategies import none, text, integers, lists, dictionaries, sampled_from
+
+from testtools.matchers import Equals
+
+from twisted.web.iweb import IResponse
+from twisted.web.http_headers import Headers
+from twisted.web.resource import Resource
+from twisted.web.client import FileBodyProducer, IAgent, readBody
+
+from lae_util.testtools import TestCase
+from lae_util.testtools.matchers import Implements, Provides
+from lae_util.testtools.strategies import path_segments
+
+from lae_util.uncooperator import Uncooperator
+from lae_util.memoryagent import MemoryAgent
+
+
+class _nothing(object):
+    """
+    No supplied value - useful primarily for the nicer way it repr()s
+    and because it is distinct from None.
+    """
+    def __repr__(self):
+        return "<nothing>"
+nothing = _nothing()
+
+
+class Recorder(Resource):
+    """
+    A resource which records the parameters of the request which is
+    dispatched to it.  Tests can then make assertions about the
+    recorded state.
+    """
+    method = nothing
+    headers = nothing
+    body = nothing
+
+    def render(self, request):
+        self.method = request.method
+        self.headers = request.requestHeaders
+        self.body = request.content.read()
+        return b""
+
+
+class Player(Resource):
+    """
+    A resource which spits out statically configured responses.  This
+    helps tests make assertions about response handling.
+    """
+    def __init__(self, code, message, headers, body):
+        Resource.__init__(self)
+        self.code = code
+        self.message = message
+        self.headers = headers
+        self.body = body
+
+    def render(self, request):
+        request.setResponseCode(self.code, self.message)
+        for k, vs in self.headers.getAllRawHeaders():
+            request.responseHeaders.setRawHeaders(k, vs)
+        return self.body
+
+
+def http_methods():
+    """
+    Strategy for generating the HTTP request verbs/methods.
+    """
+    return sampled_from((b"GET", b"POST", b"DELETE", b"PUT", b"HEAD"))
+
+
+def http_codes():
+    """
+    Strategy for generating HTTP response code integers.
+
+    Currently nothing below 200 is generated because 1xx codes have
+    some additional, complicated semantics.
+    """
+    return integers(min_value=200, max_value=599)
+
+
+def http_messages():
+    """
+    Strategy for generating alternate HTTP response messages/phrases.
+    """
+    return text().map(lambda x: x.encode("utf-8"))
+
+def http_headers():
+    """
+    Strategy for generating ``Headers`` populated with random HTTP
+    headers.
+
+    This could probably use some more work.
+    """
+    return dictionaries(
+        keys=sampled_from((
+            b"accept",
+            b"accept-charset",
+            b"accept-encoding",
+            b"accept-language",
+            b"accept-ranges",
+            b"age",
+            b"allow",
+            b"authorization",
+            b"cache-control",
+            b"connection",
+            b"content-encoding",
+            b"content-language",
+            # XXX The rest, I guess, plus randomly generate some?
+        )),
+        values=text().map(lambda x: x.encode("utf-8")),
+    ).map(
+        lambda h: Headers({k: [v] for (k, v) in h.items()})
+    )
+
+def http_bodies():
+    """
+    Strategy for generating some UTF-8 bytes usable as a request or
+    response body.
+    """
+    return text().map(lambda x: x.encode("utf-8"))
+
+
+class MemoryAgentTests(TestCase):
+    """
+    Tests for ``MemoryAgent``.
+    """
+    def test_interface(self):
+        """
+        ``MemoryAgent`` implements ``IAgent``.
+        """
+        self.assertThat(MemoryAgent, Implements(IAgent))
+
+
+    @given(
+        method=http_methods(),
+        path_segments=lists(elements=path_segments(), min_size=1),
+        headers=http_headers(),
+        body=http_bodies(),
+    )
+    def test_request(self, method, path_segments, headers, body):
+        """
+        ``MemoryAgent`` uses the ``IResource`` it is given as the root of
+        a resource hierarchy and finds the correct child to which to
+        deliver the requests represented ``MemoryAgent.request``
+        calls.
+
+        The request path is tested by selection of the correct
+        ``IResource``.  The request method, headers, and body are
+        expected to be delivered to the resource exactly as specified
+        in the ``MemoryAgent.request`` call.
+        """
+        child = recorder = Recorder()
+        parent = None
+        for segment in path_segments[::-1]:
+            parent = Resource()
+            parent.putChild(segment, child)
+            child = parent
+
+        producer = FileBodyProducer(
+            BytesIO(body), cooperator=Uncooperator()
+        )
+
+        path = b"/" + b"/".join(quote(segment, safe=b"") for segment in path_segments)
+        agent = MemoryAgent(parent)
+        response = self.successResultOf(
+            agent.request(method, path, headers, producer)
+        )
+
+        self.expectThat(recorder.method, Equals(method))
+        self.expectThat(recorder.headers, Equals(headers))
+        self.expectThat(recorder.body, Equals(body))
+
+    @given(
+        code=http_codes(),
+        # Technical the message can be empty but the Twisted API
+        # replaces empty messages with the default message for the
+        # code.  Avoid tripping over that case.
+        message=http_messages().filter(len),
+        headers=http_headers(),
+        body=http_bodies()
+    )
+    def test_response(self, code, message, headers, body):
+        """
+        ``MemoryAgent.request`` returns a ``Deferred`` which fires with an
+        ``IResponse`` provider containing the response code, message,
+        headers, and body generated by the ``IResource`` to which the
+        request was dispatched.
+        """
+        player = Player(code, message, headers, body)
+        root = Resource()
+        root.putChild("", player)
+
+        agent = MemoryAgent(root)
+        response = self.successResultOf(agent.request(b"GET", b"/", Headers()))
+
+        self.expectThat(response, Provides(IResponse))
+        self.expectThat(response.code, Equals(code))
+        self.expectThat(response.phrase, Equals(message))
+        self.expectThat(response.headers, Equals(headers))
+        self.expectThat(response.length, Equals(len(body)))
+        self.expectThat(self.successResultOf(readBody(response)), Equals(body))

--- a/lae_util/testtools/_base.py
+++ b/lae_util/testtools/_base.py
@@ -135,6 +135,20 @@ class TestCase(testtools.TestCase, _MktempMixin, _DeferredAssertionMixin):
         super(TestCase, self).setUp()
         self.useFixture(_SplitEliotLogs())
 
+    # expectThat and Hypothesis don't communicate well about when the
+    # test has failed.  Give them a little help.  These two Hypothesis
+    # hooks will check for a flag that testtools sets when it thinks
+    # the test has failed and turn it into something Hypothesis can
+    # recognize.
+    def setup_example(self):
+        try:
+            del self.force_failure
+        except AttributeError:
+            pass
+
+    def teardown_example(self, ignored):
+        if getattr(self, "force_failure", False):
+            self.fail("expectation failed")
 
 class _AsyncRunner(AsynchronousDeferredRunTestForBrokenTwisted):
     """

--- a/lae_util/testtools/matchers.py
+++ b/lae_util/testtools/matchers.py
@@ -239,3 +239,13 @@ class Implements(object):
         if not self.interface.implementedBy(actual):
             return Mismatch("{} does not implement {}".format(actual, self.interface))
         return None
+
+
+@attr.s(frozen=True)
+class Provides(object):
+    interface = attr.ib()
+
+    def match(self, actual):
+        if not self.interface.providedBy(actual):
+            return Mismatch("{} does not provide {}".format(actual, self.interface))
+        return None

--- a/lae_util/testtools/matchers.py
+++ b/lae_util/testtools/matchers.py
@@ -19,6 +19,8 @@ Hamcrest-style matchers for testtools-based tests.
 from functools import partial
 import os
 
+import attr
+
 from pyrsistent import PClass, field, pmap_field
 from testtools.content import Content
 from testtools.matchers import (
@@ -27,6 +29,7 @@ from testtools.matchers import (
     FileExists,
     MatchesAll,
     PathExists,
+    Mismatch,
 )
 
 
@@ -226,3 +229,13 @@ with_permissions = partial(
 """
 Match if path has the given permissions.
 """
+
+
+@attr.s(frozen=True)
+class Implements(object):
+    interface = attr.ib()
+
+    def match(self, actual):
+        if not self.interface.implementedBy(actual):
+            return Mismatch("{} does not implement {}".format(actual, self.interface))
+        return None

--- a/lae_util/testtools/strategies.py
+++ b/lae_util/testtools/strategies.py
@@ -24,26 +24,28 @@ from hypothesis.strategies import integers, lists, text
 from twisted.python.filepath import FilePath
 
 
-path_segments = (
-    text().
-    filter(lambda x: '/' not in x).
-    map(lambda x: x.encode('utf8')).
-    filter(lambda x: '\0' not in x))
-"""
-Individual path segments.
+def path_segments(**kw):
+    """
+    Individual path segments.
 
-These are UTF-8 encoded segments that contain neither '/' nor NULL.
+    These are UTF-8 encoded segments that contain neither '/' nor NULL.
 
-e.g. 'foo', 'rc.local'.
-"""
+    e.g. 'foo', 'rc.local'.
+    """
+    return text(min_size=1, **kw
+    ).filter(lambda x: '/' not in x
+    ).map(lambda x: x.encode('utf8')
+    ).filter(lambda x: '\0' not in x
+    )
 
 
-paths = lists(path_segments).map(lambda ps: FilePath('/'.join(ps)))
-"""
-Paths
+def paths(**kw):
+    """
+    Paths
 
-e.g. ``FilePath('/usr/local')``, ``FilePath('foo/bar/bar')``.
-"""
+    e.g. ``FilePath('/usr/local')``, ``FilePath('foo/bar/bar')``.
+    """
+    return lists(path_segments(**kw)).map(lambda ps: FilePath('/'.join(ps)))
 
 
 _identifier_characters = string.ascii_letters + string.digits + '_'

--- a/lae_util/testtools/test/test_matchers.py
+++ b/lae_util/testtools/test/test_matchers.py
@@ -70,7 +70,7 @@ class PathExistsTests(TestCase):
         path.makedirs()
         self.assertThat(path, path_exists())
 
-    @given(paths)
+    @given(paths())
     def test_equivalent_to_standard_path_exists(self, path):
         """
         path_exists is to FilePaths what PathExists is to normal paths.
@@ -109,7 +109,7 @@ class DirExistsTests(TestCase):
         path.makedirs()
         self.assertThat(path, dir_exists())
 
-    @given(paths)
+    @given(paths())
     def test_equivalent_to_standard_dir_exists(self, path):
         """
         dir_exists is to FilePaths what DirExists is to normal paths.
@@ -147,7 +147,7 @@ class FileExistsTests(TestCase):
         path = self.make_temporary_directory()
         self.assertThat(path, Not(file_exists()))
 
-    @given(paths)
+    @given(paths())
     def test_equivalent_to_standard_file_exists(self, path):
         """
         file_exists is to FilePaths what FileExists is to normal paths.

--- a/lae_util/uncooperator.py
+++ b/lae_util/uncooperator.py
@@ -1,0 +1,38 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
+"""
+An implementation of ``twisted.internet.task.Cooperator`` which
+does not do any cooperation.  This allows to to be independent of the
+reactor.  This is often useful for unit tests.
+"""
+
+from twisted.python.failure import Failure
+from twisted.internet.defer import succeed
+from twisted.internet.task import TaskDone
+
+class Uncooperator(object):
+    def cooperate(self, iterator):
+        try:
+            for ignored in iterator:
+                pass
+        except:
+            return Uncooperator(Failure())
+        else:
+            return UncooperativeTask(iterator)
+
+class UncooperativeTask(object):
+    def __init__(self, result):
+        self._result = result
+
+    def whenDone(self):
+        return succeed(self._result)
+
+    def pause(self):
+        raise TaskDone()
+
+    def resume(self):
+        pass
+
+    def stop(self):
+        raise TaskDone()


### PR DESCRIPTION
Fixes #460 

This helper is required by the unit tests for the #455 branch (455.signup-with-containers.0) where I want to test code that interacts with the Kubernetes and AWS HTTP APIs as well as a new internal HTTP API exposed by a microservice that manages subscriptions.