### PR TITLE
add config to allow old image cleanup

### DIFF
--- a/k8s/registry.yaml
+++ b/k8s/registry.yaml
@@ -55,10 +55,18 @@ spec:
             cpu: '50m'
             memory: '100Mi'
         env:
+        # Listen on this address for HTTP
         - name: 'REGISTRY_HTTP_ADDR'
           value: ':30000'
+        # Use this filesystem directory as storage
         - name: 'REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY'
           value: '/var/lib/registry'
+        # Purge abandoned uploads sometimes.
+        - name: 'REGISTRY_STORAGE_MAINTENANCE_UPLOADPURGING'
+          value: '{enabled: true, age: "24h", interval: "12h", dryrun: false}'
+        # Enable image deletion via the API
+        - name: 'REGISTRY_STORAGE_DELETE'
+          value: '{enabled: true}'
         volumeMounts:
         - name: 'image-store'
           mountPath: '/var/lib/registry'


### PR DESCRIPTION
This sets the registry options which:

  * cause automatic clean up of dangling temporary garbage
  * allow deletion of repositories, images, layers, and blobs via the API

This is likely not quite sufficient to reclaim storage since there is a separate gc step that appears necessary.  It's progress, though.
