### PR TITLE
Faster Nix Docker-image builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ matrix:
   # Each included item will be a builder.
   include:
     # This builder will run our test suite directly.
-    - env: ENV="testing" WAIT="10"
+    - env: ENV="testing"
       language: "python"
 
     # This builder will build the Nix packages (which happens to run the test
     # suite as well).
     #
     # tar on trusty doesn't have --exclude-vcs-ignores so disable it here.
-    - env: ENV="packaging" EXCLUDE_VCS_IGNORES="" WAIT="60"
+    - env: ENV="packaging" EXCLUDE_VCS_IGNORES=""
       # Force this to run in a VM since the packaging script wants to launch Docker.
       sudo: "required"
       # We don't really need any particular language runtime.
@@ -37,4 +37,4 @@ install:
 
 # Run its test suite.
 script:
-  - "travis_wait ${WAIT} ./test-tools/run-${ENV}"
+  - "./test-tools/run-${ENV}"

--- a/docker/_nix-build
+++ b/docker/_nix-build
@@ -10,7 +10,7 @@
 from __future__ import print_function, unicode_literals
 
 from sys import argv, stdout
-from datetime import datetime
+from datetime import datetime, timedelta
 from subprocess import PIPE, STDOUT, CalledProcessError, Popen
 
 from docker import from_env
@@ -41,6 +41,7 @@ def nixbuild(name, progress):
     collected_output = []
     try:
 	for output in check_incremental_output(build_command, stderr=STDOUT):
+            output = output.decode("utf-8", "replace")
             collected_output.append(output)
             progress(output)
     except CalledProcessError as e:
@@ -85,14 +86,33 @@ def buildimage(names, progress):
 
 
 def report(s):
-    stdout.write(s)
+    stdout.write(s.encode("utf-8"))
     stdout.flush()
 
 
 
+class _LimitedReporting(object):
+    def __init__(self, interval, report):
+        self.interval = interval
+        self.last_report = datetime.now() - self.interval
+        self._report = report
+
+    def report(self, what):
+        now = datetime.now()
+        if now - self.last_report > self.interval:
+            self.last_report = now
+            return self._report(what)
+        return None
+
+
+_rate_limited_reporter = _LimitedReporting(
+    interval=timedelta(seconds=2),
+    report=lambda output: report(datetime.now().isoformat() + " build progress\n"),
+)
+
 PROGRESS_REPORTERS = {
     True: report,
-    False: lambda output: report(datetime.now().isoformat() + "\n"),
+    False: _rate_limited_reporter.report,
 }
 
 

--- a/docker/_nix-build
+++ b/docker/_nix-build
@@ -31,6 +31,10 @@ def nixbuild(name, progress):
         # We rely on this later to load the result in to Docker.
         "--out-link", image_archive_filename,
 
+        # Go fast!  0 value means that nix will figure out how many cores
+        # there are and use that many.
+        "--cores", "0",
+
         # Point at the file containing the expression to derive.
         expr,
     ]

--- a/docker/_nix-build
+++ b/docker/_nix-build
@@ -10,27 +10,57 @@
 from __future__ import print_function, unicode_literals
 
 from sys import argv, stdout
-from subprocess import STDOUT, CalledProcessError, check_output
+from datetime import datetime
+from subprocess import PIPE, STDOUT, CalledProcessError, Popen
 
 from docker import from_env
 
 
-def nixbuild(name):
+def nixbuild(name, progress):
+    image_archive_filename = name + ".tar.gz"
+
     # Build it.
     expr = "/leastauthority.com/docker/{}.nix".format(name)
+    build_command = [
+        "nix-build",
+
+        # When things fail, this gives more details about where.
+        "--show-trace",
+
+        # Set the name of the file into which the derivation is written.
+        # We rely on this later to load the result in to Docker.
+        "--out-link", image_archive_filename,
+
+        # Point at the file containing the expression to derive.
+        expr,
+    ]
+    collected_output = []
     try:
-	output = check_output(
-            ["nix-build", "--show-trace", expr],
-            stderr=STDOUT,
-        )
+	for output in check_incremental_output(build_command, stderr=STDOUT):
+            collected_output.append(output)
+            progress(output)
     except CalledProcessError as e:
         report("Building {} failed:\n".format(name))
-        report(e.output)
+        report(relevant_output("".join(collected_output)))
         raise SystemExit(e.returncode)
 
-    # Get the name of the built artifact.
-    image_archive_filename = output.splitlines()[-1]
     return image_archive_filename
+
+
+
+def relevant_output(output):
+    return "\n".join(output.splitlines()[-100:]) + "\n"
+
+
+
+def check_incremental_output(command, *args, **kwargs):
+    process = Popen(command, *args, stdout=PIPE, **kwargs)
+    for line in process.stdout:
+        yield line
+    returncode = process.wait()
+    if returncode != 0:
+        raise CalledProcessError(returncode, command)
+
 
 
 def loadimage(image_archive_filename):
@@ -40,16 +70,49 @@ def loadimage(image_archive_filename):
         client.images.load(image_archive.read())
 
 
-def main(names):
+
+def buildimage(names, progress):
     for name in names:
         report("Building {}...\n".format(name))
-        result = nixbuild(name.decode("utf-8"))
-        report("Build complete.  Loading {}...\n".format(result))
-        loadimage(result)
-        report("Load complete.\n")
+        result = nixbuild(name.decode("utf-8"), progress)
+        report("Build complete.\n")
+        yield result
+
+
 
 def report(s):
     stdout.write(s)
     stdout.flush()
+
+
+
+PROGRESS_REPORTERS = {
+    True: report,
+    False: lambda output: report(datetime.now().isoformat() + "\n"),
+}
+
+
+def main(argv):
+    try:
+        argv.remove("--verbose")
+    except ValueError:
+        verbose = False
+    else:
+        verbose = True
+    try:
+        argv.remove("--load")
+    except ValueError:
+        load = False
+    else:
+        load = True
+
+    progress = PROGRESS_REPORTERS[verbose]
+    for path in buildimage(argv, progress):
+        if load:
+            report("Loading {}...\n".format(path))
+            loadimage(path)
+            report("Load complete.\n")
+
+
 
 main(argv[1:])

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,5 +1,11 @@
 #!/bin/sh -ex
 
+# Options:
+#
+#   --load      Load the Nix-built Docker images into the local Docker daemon.
+#   --verbose   Dump output from the Nix build process
+
+
 LEASTAUTHORITY=${PWD}/$(dirname $(dirname $0))
 
 NIX_STORE=/nix
@@ -13,20 +19,22 @@ if [ -z ${EXCLUDE_VCS_IGNORES+x} ]; then
     EXCLUDE_VCS_IGNORES="--exclude-vcs-ignores"
 fi
 
+build_command="
+mkdir /leastauthority.com
+tar xf - -C /leastauthority.com
+nix-channel --remove nixpkgs
+nix-channel --add https://nixos.org/channels/nixos-17.03 nixpkgs
+nix-channel --update
+/leastauthority.com/docker/_nix-build $@ web grid-router subscription-manager subscription-converger
+"
+
 # Get a Nix toolchain environment we can use for the next few steps.
 tar cf - -C "${LEASTAUTHORITY}" --exclude-vcs ${EXCLUDE_VCS_IGNORES} . | docker run \
        --rm \
        --interactive \
        --volume ${CACHE_VOLUME}:${NIX_STORE} \
        --volume /var/run/docker.sock:/var/run/docker.sock \
-       numtide/nix-builder /bin/env /bin/sh -exc "
-           mkdir /leastauthority.com
-           tar xf - -C /leastauthority.com
-           nix-channel --remove nixpkgs
-           nix-channel --add https://nixos.org/channels/nixos-17.03 nixpkgs
-           nix-channel --update
-           /leastauthority.com/docker/_nix-build web grid-router subscription-manager subscription-converger
-       "
+       numtide/nix-builder /bin/env /bin/sh -exc "${build_command}"
 
 images="base tahoe-base foolscap-base foolscap-gatherer"
 tahoe_images="tahoe-introducer tahoe-storage"

--- a/docker/grid-router.nix
+++ b/docker/grid-router.nix
@@ -5,9 +5,9 @@ pkgs.dockerTools.buildImage {
   name = "leastauthority/grid-router";
   fromImage = lae.s4-common-image;
   config = {
+    Env = lae.s4-common-image.buildArgs.config.Env;
+    EntryPoint = ["/bin/dash" "-c"];
     Cmd = [
-      "/bin/dash"
-      "-c"
       (pkgs.lib.strings.concatStringsSep " " [
         "/bin/twist" "s4-grid-router"
 	"--k8s-service-account"

--- a/docker/lae.nix
+++ b/docker/lae.nix
@@ -434,12 +434,6 @@ rec {
 
   s4-common-image = pkgs.dockerTools.buildImage {
       name = "leastauthority/s4-common";
-      runAsRoot = ''
-        #!${pkgs.stdenv.shell}
-        ${pkgs.dockerTools.shadowSetup}
-        groupadd --system lae
-        useradd --system --gid lae --home-dir /app/data lae
-      '';
       config = {
         Env = [
           # pkgs.cacert below provides this file.  The simple ca certificate

--- a/docker/lae.nix
+++ b/docker/lae.nix
@@ -424,7 +424,9 @@ rec {
       builtins.filterSource goodSource ./..;
 
     checkPhase = ''
-      ./test-tools/run-testing
+      # Try building with as many cores as Nix says we have to use, or just 1
+      # if Nix doesn't seem to be telling us anything.
+      ./test-tools/run-testing -j $NIX_BUILD_CORES
     '';
 
     meta = {

--- a/docker/subscription-converger.nix
+++ b/docker/subscription-converger.nix
@@ -6,10 +6,9 @@ pkgs.dockerTools.buildImage {
   fromImage = lae.s4-common-image;
   config = {
     Env = lae.s4-common-image.buildArgs.config.Env;
+    EntryPoint = ["/bin/dash" "-c"];
     Cmd =
       [
-        "/bin/dash"
-        "-c"
         (pkgs.lib.strings.concatStringsSep " " [
           "twist" "s4-subscription-converger"
           "--domain" "$(cat /app/k8s_secrets/domain)"

--- a/docker/subscription-manager.nix
+++ b/docker/subscription-manager.nix
@@ -5,10 +5,10 @@ pkgs.dockerTools.buildImage {
   name = "leastauthority/subscription-manager";
   fromImage = lae.s4-common-image;
   config = {
+    Env = lae.s4-common-image.buildArgs.config.Env;
+    EntryPoint = ["/bin/dash" "-c"];
     Cmd =
       [
-        "/bin/dash"
-        "-c"
         (pkgs.lib.strings.concatStringsSep " " [
           "twist" "s4-subscription-manager"
           "--domain" "$(cat /app/k8s_secrets/domain)"

--- a/docker/web.nix
+++ b/docker/web.nix
@@ -5,6 +5,8 @@ pkgs.dockerTools.buildImage {
   name = "leastauthority/web";
   fromImage = lae.s4-common-image;
   config = {
+    Env = lae.s4-common-image.buildArgs.config.Env;
+    EntryPoint = ["/bin/dash" "-c"];
     Cmd =
       let
         port = "8443";
@@ -13,8 +15,6 @@ pkgs.dockerTools.buildImage {
         chain = "extraCertChain=/app/k8s_secrets/website-chain.pem";
       in
         [
-          "/bin/dash"
-          "-c"
           (pkgs.lib.strings.concatStringsSep " " [
             "/bin/python" "-u" "/${pkgs.python27.sitePackages}/lae_site/main.py"
             "--secure-port=ssl:${port}:${cert}:${key}:${chain}"

--- a/k8s/build-tag-push
+++ b/k8s/build-tag-push
@@ -8,7 +8,7 @@ SERVER="127.0.0.1:${SERVER_PORT}"
 microservices="web grid-router tahoe-introducer tahoe-storage foolscap-gatherer subscription-manager subscription-converger"
 
 # Build the images.
-./leastauthority.com/docker/build.sh
+./leastauthority.com/docker/build.sh --verbose --load
 
 # Tag them in the way expected by the deployment configuration and
 # with the tag given in the environment.

--- a/test-tools/run-testing
+++ b/test-tools/run-testing
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 test-tools/check-miscaptures.py
-PYTHONPATH=${PWD}:${PYTHONPATH} trial lae_util lae_site grid_router lae_automation
+PYTHONPATH=${PWD}:${PYTHONPATH} trial "$@" lae_util lae_site grid_router lae_automation


### PR DESCRIPTION
Fixes #533 

Removes runAsRoot as advertised.  Additionally:

  * tries harder to satisfy travis's build output constraints (not too little, not too much)
  * tries to use more cores to run our test suite, if more cores are available

Build times go from 20-30 minutes to 10-20 minutes.