### PR TITLE
Bridge from Twisted and stdlib logging to Eliot

### DIFF
--- a/lae_util/eliottools.py
+++ b/lae_util/eliottools.py
@@ -1,0 +1,41 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
+"""
+Eliot-related functionality.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+from json import loads
+
+import attr
+from attr.validators import optional, provides
+
+from zope.interface import implementer
+
+from eliot import ILogger, Message
+
+from twisted.logger import ILogObserver, eventAsJSON
+
+
+@implementer(ILogObserver)
+@attr.s(frozen=True)
+class TwistedLoggerToEliotObserver(object):
+    """
+    An ``ILogObserver`` which re-publishes events as Eliot messages.
+    """
+    logger = attr.ib(default=None, validator=optional(provides(ILogger)))
+
+    def _observe(self, event):
+        flattened = loads(eventAsJSON(event))
+        # We get a timestamp from Eliot.
+        flattened.pop("log_time")
+        # This is never serializable anyway.
+        flattened.pop("log_logger")
+
+        Message.new(**flattened).write(self.logger)
+
+
+    # The actual ILogObserver interface uses this.
+    __call__ = _observe

--- a/lae_util/eliottools.py
+++ b/lae_util/eliottools.py
@@ -34,8 +34,9 @@ class TwistedLoggerToEliotObserver(object):
         flattened = loads(eventAsJSON(event))
         # We get a timestamp from Eliot.
         flattened.pop("log_time")
-        # This is never serializable anyway.
-        flattened.pop("log_logger")
+        # This is never serializable anyway.  "Legacy" log events (from
+        # twisted.python.log) don't have this so make it optional.
+        flattened.pop("log_logger", None)
 
         Message.new(**flattened).write(self.logger)
 

--- a/lae_util/test/test_eliot.py
+++ b/lae_util/test/test_eliot.py
@@ -7,15 +7,21 @@ Tests for ``lae_util.eliottools``.
 
 from __future__ import print_function, unicode_literals
 
+import logging
+
 from testtools.matchers import Equals, IsInstance, ContainsDict
 
+from twisted.python.reflect import fullyQualifiedName
 from twisted.logger import Logger as TwistedLogger
 
 from eliot import MemoryLogger as EliotLogger
 from eliot.testing import capture_logging
 
 from ..testtools import TestCase
-from ..eliottools import TwistedLoggerToEliotObserver
+from ..eliottools import (
+    TwistedLoggerToEliotObserver,
+    stdlib_logging_to_eliot_configuration,
+)
 
 
 class TwistedLoggerToEliotObserverTests(TestCase):
@@ -56,7 +62,6 @@ class TwistedLoggerToEliotObserverTests(TestCase):
         twisted_logger.info("Hello, world.")
 
         [event] = eliot_logger.messages
-
         self.assertThat(
             event,
             ContainsDict(dict(
@@ -64,6 +69,60 @@ class TwistedLoggerToEliotObserverTests(TestCase):
                 log_namespace=Equals("lae_util.test.test_eliot"),
                 log_format=Equals("Hello, world."),
                 # And also some Eliot stuff.
+                task_uuid=IsInstance(unicode),
+                task_level=IsInstance(list),
+            )),
+        )
+
+
+
+class StdlibLoggingToELiotHandlerTests(TestCase):
+    """
+    Tests for ``_StdlibLoggingToEliotHandler``.
+    """
+    def test_relaying(self):
+        """
+        When ``stdlib_logging_to_eliot_configuration`` is used on a
+        ``logging.Logger``, in force, log events emitted via that logger are
+        published to the ``eliot.Logger`` the handler was constructed with.
+        """
+        eliot_logger = EliotLogger()
+        self._relaying_test(eliot_logger, eliot_logger)
+
+
+    @capture_logging(None)
+    def test_default_logger(self, eliot_logger):
+        """
+        ``stdlib_logging_to_eliot_configuration`` uses the default Eliot logger
+        when it is not passed one.
+        """
+        self._relaying_test(None, eliot_logger)
+
+
+    def _relaying_test(self, eliot_logger_publish, eliot_logger_consume):
+        """
+        Publish an event using ``logger.Logger` with an Eliot relay handler hooked
+        up to the root logger and assert that the event ends up b eing seen by
+        ``eliot_logger_consumer`.
+        """
+        cleanup = stdlib_logging_to_eliot_configuration(
+            logging.getLogger(),
+            eliot_logger_publish,
+        )
+        self.addCleanup(cleanup)
+
+        logger = logging.getLogger(fullyQualifiedName(self.__class__))
+        logger.setLevel(logging.INFO)
+        logger.info("Hello, world.")
+
+        [event] = eliot_logger_consume.messages
+        self.assertThat(
+            event,
+            ContainsDict(dict(
+                # A couple things from the stdlib side of the fence.
+                module=Equals(__name__.split(".")[-1]),
+                levelno=Equals(logging.INFO),
+                # Also some Eliot stuff.
                 task_uuid=IsInstance(unicode),
                 task_level=IsInstance(list),
             )),

--- a/lae_util/test/test_eliot.py
+++ b/lae_util/test/test_eliot.py
@@ -1,0 +1,70 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
+"""
+Tests for ``lae_util.eliottools``.
+"""
+
+from __future__ import print_function, unicode_literals
+
+from testtools.matchers import Equals, IsInstance, ContainsDict
+
+from twisted.logger import Logger as TwistedLogger
+
+from eliot import MemoryLogger as EliotLogger
+from eliot.testing import capture_logging
+
+from ..testtools import TestCase
+from ..eliottools import TwistedLoggerToEliotObserver
+
+
+class TwistedLoggerToEliotObserverTests(TestCase):
+    """
+    Tests for ``TwistedLoggerToEliotObserver``.
+    """
+    def test_relaying(self):
+        """
+        Log events emitted via a ``twisted.logger.Logger`` with a
+        ``TwistedLoggerToEliotObserver`` end up published to the
+        ``eliot.Logger`` the observer was constructed with.
+        """
+        eliot_logger = EliotLogger()
+        self._relaying_test(
+            eliot_logger,
+            TwistedLoggerToEliotObserver(eliot_logger),
+        )
+
+
+    @capture_logging(None)
+    def test_default_logger(self, eliot_logger):
+        """
+        ``TwistedLoggerToEliotObserver`` created without a logger publishes to the
+        default logger.
+        """
+        self._relaying_test(
+            eliot_logger,
+            TwistedLoggerToEliotObserver(),
+        )
+
+
+    def _relaying_test(self, eliot_logger, observer):
+        """
+        Publish an event using ``twisted.logger`` with ``observer`` hooked up and
+        assert that the event ends up being seen by ``eliot_logger``.
+        """
+        twisted_logger = TwistedLogger(observer=observer)
+        twisted_logger.info("Hello, world.")
+
+        [event] = eliot_logger.messages
+
+        self.assertThat(
+            event,
+            ContainsDict(dict(
+                # A couple things from the Twisted side of the fence.
+                log_namespace=Equals("lae_util.test.test_eliot"),
+                log_format=Equals("Hello, world."),
+                # And also some Eliot stuff.
+                task_uuid=IsInstance(unicode),
+                task_level=IsInstance(list),
+            )),
+        )


### PR DESCRIPTION
Fixes #557 

This doesn't _disable_ Twisted logging to stdout in most cases.  `twist` makes it difficult to do that.  So some processes will still have some logs on their stdout, collected by Docker/Kubernetes.  Those log events will all _also_ go to Eliot and Fluentd, though.