### PR TITLE
improved wormhole signup page

### DIFF
--- a/src/lae_automation/signup.py
+++ b/src/lae_automation/signup.py
@@ -88,7 +88,7 @@ class ISignup(Interface):
 
 
 class IClaim(Interface):
-    def describe():
+    def describe(env):
         """
         Explain the details of this claim in a way that can be rendered into a web
         page.
@@ -170,13 +170,11 @@ class _EmailSignup(object):
             return d.addActionFinish()
 
 
+
 @implementer(IClaim)
 class _EmailClaim(object):
-    description = (
-        u"We'll send you an email with your unique introducer furl within the next hour."
-    )
-    def describe(self):
-        return self.description
+    def describe(self, env):
+        return env.get_template("email_activation.html").render({})
 
 
 
@@ -435,5 +433,8 @@ class _WormholeClaim(object):
     code = attr.ib(validator=validators.instance_of(unicode))
     expires = attr.ib()
 
-    def describe(self):
-        return self.code + unicode(self.expires)
+    def describe(self, env):
+        tmpl = env.get_template("gridsync_activation.html")
+        return tmpl.render({
+            "claim": self.code,
+        })

--- a/src/lae_site/handlers/submit_subscription.py
+++ b/src/lae_site/handlers/submit_subscription.py
@@ -162,7 +162,7 @@ def signed_up(claim, request):
         tmpl.render({
             "productfullname": "Simple Secure Storage Service",
             "productname":"S4",
-            "claim": claim.describe(),
+            "activationinfo": claim.describe(env),
         }).encode('utf-8'),
     )
     request.finish()

--- a/src/lae_site/handlers/test/test_submit_subscription.py
+++ b/src/lae_site/handlers/test/test_submit_subscription.py
@@ -24,7 +24,7 @@ class TrivialClaim(object):
     subscription_id = attr.ib()
     plan_id = attr.ib()
 
-    def describe(self):
+    def describe(self, env):
         return "You subscribed."
 
 

--- a/src/lae_site/templates/email_activation.html
+++ b/src/lae_site/templates/email_activation.html
@@ -1,0 +1,22 @@
+{% block content %}
+
+<p>
+  Before you get started,
+  you will need to <a href="https://tahoe-lafs.org/trac/tahoe-lafs/wiki/Installation">install LAFS</a> on your trusted machine.
+  After you've installed LAFS,
+  you can configure it with the furl you'll be receiving in your email.
+</p>
+
+<p>
+  We'll send you an email with your unique introducer furl within the next hour.
+</p>
+
+<p>
+  If you've still not received an email within an hour,
+  please make sure that your mail client didn't mark it as spam,
+  and notify us at &lt;<a href="mailto:support@LeastAuthority.com">support@LeastAuthority.com</a>&gt;.
+  You can also contact us at this address to cancel or change your subscription,
+  or if you have any problem with the service.
+</p>
+
+{% endblock %}

--- a/src/lae_site/templates/gridsync_activation.html
+++ b/src/lae_site/templates/gridsync_activation.html
@@ -9,7 +9,10 @@
   <a href="https://github.com/warner/magic-wormhole">(?)</a>:
 </p>
 
-<p style="text-align: center;">
+<!-- The wormhole code is the really important piece of information on this
+     page.  Make it stand out visually with emphasis, increased size, and
+     central position on the page.  -->
+<p style="text-align: center; font-size: 125%;">
   <strong>{{ claim }}</strong>.
 </p>
 

--- a/src/lae_site/templates/gridsync_activation.html
+++ b/src/lae_site/templates/gridsync_activation.html
@@ -3,7 +3,11 @@
 <p>
   Take this opportunity to download and install Gridsync --
   a new, easy-to-use graphical user interface for Tahoe-LAFS.
-  When prompted, enter the following single-use invite code: <strong>{{ claim }}</strong>.
+  When prompted, enter the following single-use invite code:
+</p>
+
+<p style="text-align: center;">
+  <strong>{{ claim }}</strong>.
 </p>
 
 <p>

--- a/src/lae_site/templates/gridsync_activation.html
+++ b/src/lae_site/templates/gridsync_activation.html
@@ -1,7 +1,7 @@
 {% block content %}
 
 <p>
-  Take this opportunity to download and install Gridsync --
+  Take this opportunity to download and install Gridsync &ndash;
   a new, easy-to-use graphical user interface for Tahoe-LAFS.
   When prompted, enter the following single-use invite code:
 </p>

--- a/src/lae_site/templates/gridsync_activation.html
+++ b/src/lae_site/templates/gridsync_activation.html
@@ -1,9 +1,8 @@
 {% block content %}
 
 <p>
-  Take this opportunity to download and install Gridsync
-  <a href="https://github.com/gridsync/gridsync">(?)</a>
-  &ndash;
+  Take this opportunity to download and install
+  <a href="https://github.com/gridsync/gridsync">Gridsync</a> &ndash;
   a new graphical user interface for Tahoe-LAFS for joining storage grids and creating magic-folders.
   When prompted, enter the following single-use invite code
   <a href="https://github.com/warner/magic-wormhole">(?)</a>:

--- a/src/lae_site/templates/gridsync_activation.html
+++ b/src/lae_site/templates/gridsync_activation.html
@@ -19,18 +19,18 @@
   <ul>
     <li>
       <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Linux.tar.gz">Linux</a>
-      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Linux.tar.gz.asc">sig</a>
-      <a href="https://en.wikipedia.org/wiki/Digital_signature">(?)</a>]
+      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Linux.tar.gz.asc">sig</a>]
+      <a href="https://en.wikipedia.org/wiki/Digital_signature">(?)</a>
     </li>
     <li>
       <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Mac.dmg">Mac</a>
-      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Mac.dmg.asc">sig</a>
-      <a href="https://en.wikipedia.org/wiki/Digital_signature">(?)</a>]
+      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Mac.dmg.asc">sig</a>]
+      <a href="https://en.wikipedia.org/wiki/Digital_signature">(?)</a>
     </li>
     <li>
       <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Windows.zip">Windows</a>
-      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Windows.zip.asc">sig</a>
-      <a href="https://en.wikipedia.org/wiki/Digital_signature">(?)</a>]
+      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Windows.zip.asc">sig</a>]
+      <a href="https://en.wikipedia.org/wiki/Digital_signature">(?)</a>
     </li>
     <li>
       <a href="https://github.com/gridsync/gridsync/archive/v0.0.5.tar.gz">source code</a>

--- a/src/lae_site/templates/gridsync_activation.html
+++ b/src/lae_site/templates/gridsync_activation.html
@@ -1,9 +1,12 @@
 {% block content %}
 
 <p>
-  Take this opportunity to download and install Gridsync &ndash;
+  Take this opportunity to download and install Gridsync
+  <a href="https://github.com/gridsync/gridsync">(?)</a>
+  &ndash;
   a new graphical user interface for Tahoe-LAFS for joining storage grids and creating magic-folders.
-  When prompted, enter the following single-use invite code:
+  When prompted, enter the following single-use invite code
+  <a href="https://github.com/warner/magic-wormhole">(?)</a>:
 </p>
 
 <p style="text-align: center;">
@@ -14,15 +17,18 @@
   <ul>
     <li>
       <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Linux.tar.gz">Linux</a>
-      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Linux.tar.gz.asc">sig</a>]
+      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Linux.tar.gz.asc">sig</a>
+      <a href="https://en.wikipedia.org/wiki/Digital_signature">(?)</a>]
     </li>
     <li>
       <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Mac.dmg">Mac</a>
-      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Mac.dmg.asc">sig</a>]
+      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Mac.dmg.asc">sig</a>
+      <a href="https://en.wikipedia.org/wiki/Digital_signature">(?)</a>]
     </li>
     <li>
       <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Windows.zip">Windows</a>
-      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Windows.zip.asc">sig</a>]
+      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Windows.zip.asc">sig</a>
+      <a href="https://en.wikipedia.org/wiki/Digital_signature">(?)</a>]
     </li>
     <li>
       <a href="https://github.com/gridsync/gridsync/archive/v0.0.5.tar.gz">source code</a>

--- a/src/lae_site/templates/gridsync_activation.html
+++ b/src/lae_site/templates/gridsync_activation.html
@@ -1,0 +1,36 @@
+{% block content %}
+
+<p>
+  Take this opportunity to download and install Gridsync --
+  a new, easy-to-use graphical user interface for Tahoe-LAFS.
+  When prompted, enter the following single-use invite code: <strong>{{ claim }}</strong>.
+</p>
+
+<p>
+  <ul>
+    <li>
+      <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Linux.tar.gz">Linux</a>
+      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Linux.tar.gz.asc">sig</a>]
+    </li>
+    <li>
+      <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Mac.dmg">Mac</a>
+      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Mac.dmg.asc">sig</a>]
+    </li>
+    <li>
+      <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Windows.zip">Windows</a>
+      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Windows.zip.asc">sig</a>]
+    </li>
+    <li>
+      <a href="https://github.com/gridsync/gridsync/archive/v0.0.5.tar.gz">source code</a>
+    </li>
+  </ul>
+</p>
+
+<p>
+  If you have any difficulty installing Gridsync or using the invite code,
+  please contact our <a href="mailto:support@leastauthority.com">support address</a>.
+  You can also contact us at this address to cancel or change your subscription,
+  or if you have any other problems with the service.
+</p>
+
+{% endblock %}

--- a/src/lae_site/templates/gridsync_activation.html
+++ b/src/lae_site/templates/gridsync_activation.html
@@ -2,7 +2,7 @@
 
 <p>
   Take this opportunity to download and install Gridsync &ndash;
-  a new, easy-to-use graphical user interface for Tahoe-LAFS.
+  a new graphical user interface for Tahoe-LAFS for joining storage grids and creating magic-folders.
   When prompted, enter the following single-use invite code:
 </p>
 

--- a/src/lae_site/templates/payment_verified.html
+++ b/src/lae_site/templates/payment_verified.html
@@ -5,19 +5,34 @@
 <h3>Thank you</h3>
 
 <p>
-  Thank you for subscribing to the {{ productfullname }}!
-</p>
-
-<p>
-  Thank you for signing up for Least Authority’s Simple Secure Storage Service (S4)!
+  Thank you for signing up for Least Authority’s {{ productfullname }}!
   We are deploying the infrastructure necessary to support your Cloud service!
 </p>
 
 <p>
-  Take this opportunity to download Gridsync --
-  a new, easy-to-use graphical user interface for Tahoe-LAFS --
-  <a href="">download it</a> and, when prompted after installation,
-  enter the following single-use invite code: <strong>{{ claim }}</strong>.
+  Take this opportunity to download and install Gridsync --
+  a new, easy-to-use graphical user interface for Tahoe-LAFS.
+  When prompted, enter the following single-use invite code: <strong>{{ claim }}</strong>.
+</p>
+
+<p>
+  <ul>
+    <li>
+      <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Linux.tar.gz">Linux</a>
+      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Linux.tar.gz.asc">sig</a>]
+    </li>
+    <li>
+      <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Mac.dmg">Mac</a>
+      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Mac.dmg.asc">sig</a>]
+    </li>
+    <li>
+      <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Windows.zip">Windows</a>
+      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Windows.zip.asc">sig</a>]
+    </li>
+    <li>
+      <a href="https://github.com/gridsync/gridsync/archive/v0.0.5.tar.gz">source code</a>
+    </li>
+  </ul>
 </p>
 
 <p>

--- a/src/lae_site/templates/payment_verified.html
+++ b/src/lae_site/templates/payment_verified.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-<h3>Thank you</h3>
+<h3>Sign-Up Complete!</h3>
 
 <p>
   Thank you for signing up for Least Authority’s {{ productfullname }} ({{productname}})!

--- a/src/lae_site/templates/payment_verified.html
+++ b/src/lae_site/templates/payment_verified.html
@@ -3,25 +3,28 @@
 {% block content %}
 
 <h3>Thank you</h3>
+
 <p>
-Thank you for subscribing to the {{ productfullname }}!
+  Thank you for subscribing to the {{ productfullname }}!
 </p>
+
 <p>
-We are deploying the infrastructure necessary to support your Cloud service!
-{{ claim }}
+  Thank you for signing up for Least Authority’s Simple Secure Storage Service (S4)!
+  We are deploying the infrastructure necessary to support your Cloud service!
 </p>
+
 <p>
-Before you start using {{ productname }}, you will need to
-<a href="https://tahoe-lafs.org/trac/tahoe-lafs/wiki/Installation">install LAFS</a> on your
-trusted machine. After you've installed LAFS, you can configure it with the
-furl you'll be receiving in your email.
+  Take this opportunity to download Gridsync --
+  a new, easy-to-use graphical user interface for Tahoe-LAFS --
+  <a href="">download it</a> and, when prompted after installation,
+  enter the following single-use invite code: <strong>{{ claim }}</strong>.
 </p>
+
 <p>
-If you've still not received an email within the hour, please make sure that
-your mail client didn't mark it as spam, and notify us at
-&lt;<a href="mailto:support@LeastAuthority.com">support@LeastAuthority.com</a>&gt;.
-You can also contact us at this address to cancel or change your subscription,
-or if you have any problem with the service.
+  If you have any difficulty installing Gridsync or using the invite code,
+  please contact our <a href="mailto:support@leastauthority.com">support address</a>.
+  You can also contact us at this address to cancel or change your subscription,
+  or if you have any other problems with the service.
 </p>
 
 {% endblock %}

--- a/src/lae_site/templates/payment_verified.html
+++ b/src/lae_site/templates/payment_verified.html
@@ -5,41 +5,10 @@
 <h3>Thank you</h3>
 
 <p>
-  Thank you for signing up for Least Authority’s {{ productfullname }}!
+  Thank you for signing up for Least Authority’s {{ productfullname }} ({{productname}})!
   We are deploying the infrastructure necessary to support your Cloud service!
 </p>
 
-<p>
-  Take this opportunity to download and install Gridsync --
-  a new, easy-to-use graphical user interface for Tahoe-LAFS.
-  When prompted, enter the following single-use invite code: <strong>{{ claim }}</strong>.
-</p>
-
-<p>
-  <ul>
-    <li>
-      <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Linux.tar.gz">Linux</a>
-      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Linux.tar.gz.asc">sig</a>]
-    </li>
-    <li>
-      <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Mac.dmg">Mac</a>
-      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Mac.dmg.asc">sig</a>]
-    </li>
-    <li>
-      <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Windows.zip">Windows</a>
-      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Windows.zip.asc">sig</a>]
-    </li>
-    <li>
-      <a href="https://github.com/gridsync/gridsync/archive/v0.0.5.tar.gz">source code</a>
-    </li>
-  </ul>
-</p>
-
-<p>
-  If you have any difficulty installing Gridsync or using the invite code,
-  please contact our <a href="mailto:support@leastauthority.com">support address</a>.
-  You can also contact us at this address to cancel or change your subscription,
-  or if you have any other problems with the service.
-</p>
+{{ activationinfo }}
 
 {% endblock %}


### PR DESCRIPTION
Fixes #495 

For reviewer convenience, attached are screenshots of the two signup confirmation pages, one for email-based signup and the other for wormhole-based signup.

email:
![email-signup-confirmation](https://user-images.githubusercontent.com/254565/27974410-e544568a-632b-11e7-873f-a2bffa9aaa4f.png)

wormhole:
![wormhole-signup-confirmation](https://user-images.githubusercontent.com/254565/27974422-f3bf1dbc-632b-11e7-8859-1a1dbf4fa7ad.png)
