### PR TITLE
Monitoring fixes

### DIFF
--- a/k8s/monitoring/grafana.yaml
+++ b/k8s/monitoring/grafana.yaml
@@ -20,6 +20,26 @@ spec:
     component: 'Monitoring'
     service: 'grafana'
 ---
+apiVersion: 'v1'
+kind: 'Service'
+metadata:
+  name: 'grafana-internal'
+  labels:
+    provider: 'LeastAuthority'
+    component: 'Monitoring'
+    service: 'grafana'
+spec:
+  type: 'NodePort'
+  ports:
+  - name: 'web'
+    port: 80
+    targetPort: 3000
+    protocol: 'TCP'
+  selector:
+    provider: 'LeastAuthority'
+    component: 'Monitoring'
+    service: 'grafana'
+---
 apiVersion: 'extensions/v1beta1'
 kind: 'Deployment'
 metadata:
@@ -153,7 +173,7 @@ spec:
         image: 'quay.io/coreos/grafana-watcher:v0.0.4'
         args:
           - '--watch-dir=/var/grafana-dashboards'
-          - '--grafana-url=http://grafana:3000/'
+          - '--grafana-url=http://grafana-internal/'
         env:
 
         # First tell it how to gain admin access to Grafana.

--- a/k8s/monitoring/grafana.yaml
+++ b/k8s/monitoring/grafana.yaml
@@ -100,9 +100,11 @@ spec:
         - name: 'GF_AUTH_ANONYMOUS_ENABLED'
           value: 'false'
 
-        # We'll use OAuth2, we don't want a Grafana sign in form at all.
+        # We'll use OAuth2 for normal access but we need username/password
+        # access to access the admin account.  We don't often need that, but
+        # probably sometimes we do.
         - name: 'GF_AUTH_DISABLE_LOGIN_FORM'
-          value: 'true'
+          value: 'false'
 
         # Grafana must know its own hostname to successfully use an OAuth2
         # provider (to generate the correct callback URL).
@@ -145,13 +147,6 @@ spec:
           value: '' # TODO Put a team here
         - name: 'GF_AUTH_GITHUB_ALLOWED_ORGANIZATIONS'
           value: 'LeastAuthority'
-
-        # This was helpful when setting up Grafana for the first time.  It
-        # makes everyone who logs in an admin.  Admin can see more things in
-        # the web ui (eg broken data sources).  It's not really a good idea in
-        # general for the obvious reasons.
-        # - name: 'GF_USERS_AUTO_ASSIGN_ORG_ROLE'
-        #   value: 'Admin'
 
         volumeMounts:
         - name: 'grafana-storage'

--- a/k8s/monitoring/prometheus.yaml
+++ b/k8s/monitoring/prometheus.yaml
@@ -7,7 +7,7 @@ spec:
   serviceMonitorSelector:
     matchLabels:
       provider: 'LeastAuthority'
-      componnet: 'Monitoring'
+      component: 'Monitoring'
   version: 'v1.7.0'
   resources:
     requests:


### PR DESCRIPTION
After merging the monitoring PR and trying to deploy it to production, I discovered a few problems.

  * Prometheus was not selecting its ServiceMonitor.  I didn't notice this in staging because I found and fixed a label type in _one_ place but not the other.  When the typo was in both places, everything worked.  When I fixed one, it broke.  I didn't re-deploy everything on staging after fixing the typo so I didn't notice it had broken.
  * The grafana config sidecar wasn't able to talk to the grafana container.  This is probably because there was no explicit service exposing grafana (even internally).  I don't know why this _did_ work on staging but _did not_ work on production, though.
  * I immediately wanted admin access to grafana (since it wasn't working) and it was easier to change the config to allow me to log in with the hard-coded admin user as to toggle the make-all-users-admins-then-make-them-regular-again config setting.  So I just left admin access enabled.  This should be safe, the password is strong.