### PR TITLE
Build images on k8s

### DIFF
--- a/k8s/build
+++ b/k8s/build
@@ -29,7 +29,7 @@ def equals(expected):
     return check
 
 def main(rev=None):
-    context_name = u"dev"
+    context_name = u"k8s-staging.leastauthority.com"
     template = HERE.child("build-image-template.yaml")
     with template.open() as fObj:
         job = freeze(safe_load(fObj))

--- a/k8s/build-image-template.yaml
+++ b/k8s/build-image-template.yaml
@@ -40,6 +40,18 @@ spec:
         - name: 'docker'
           hostPath:
             path: '/var/run/docker.sock'
+        # And give it the secrets it needs in order to push images to Docker
+        # Hub which we will continue to use as a registry even though we don't
+        # use its automated builds feature.
+        - name: 'credentials'
+          secret:
+            secretName: 'dockerhub'
+            defaultMode: 0444
+            items:
+            - key: 'username'
+              path: 'username'
+            - key: 'password'
+              path: 'password'
       containers:
         - name: 'build'
           image: 'ubuntu:16.04'
@@ -48,8 +60,8 @@ spec:
           # customer pods.
           resources:
             limits:
-              cpu: '200m'
-              memory: '500Mi'
+              cpu: '1000m'
+              memory: '768Mi'
           env:
             # This will have a value substituted by the build driver.
             - name: "GIT_REV"
@@ -61,6 +73,9 @@ spec:
             # The other half of exposing Docker to the container...
             - name: 'docker'
               mountPath: '/var/run/docker.sock'
+            # The other half of exposing Docker Hub credentials to the container...
+            - name: 'credentials'
+              mountPath: '/var/run/secrets/dockerhub'
           command:
             # The command is the minimal amount of work we need to get a build
             # script from the repository which can take over for us.

--- a/k8s/build-tag-push
+++ b/k8s/build-tag-push
@@ -2,6 +2,7 @@
 # Copyright Least Authority Enterprises.
 # See LICENSE for details.
 
+repo="leastauthority"
 microservices="s4-common tahoe-introducer tahoe-storage foolscap-gatherer"
 
 # Build the images.
@@ -15,7 +16,7 @@ yes | docker login \
 
 # And push them.
 for microservice in ${microservices}; do
-    docker push "${microservice}:${DOCKER_TAG}"
+    docker push "${repo}/${microservice}:${DOCKER_TAG}"
 done
 
 docker logout

--- a/k8s/build-tag-push
+++ b/k8s/build-tag-push
@@ -8,7 +8,9 @@ microservices="s4-common tahoe-introducer tahoe-storage foolscap-gatherer"
 ./leastauthority.com/docker/build.sh
 
 # Log in to Docker Hub so we can push the images.
-docker login "$(cat /var/run/secrets/dockerhub/username)" "$(cat /var/run/secrets/dockerhub/password)"
+docker login \
+       --username "$(cat /var/run/secrets/dockerhub/username)" \
+       --password "$(cat /var/run/secrets/dockerhub/password)"
 
 # And push them.
 for microservice in ${microservices}; do

--- a/k8s/build-tag-push
+++ b/k8s/build-tag-push
@@ -14,9 +14,10 @@ yes | docker login \
        --username "$(cat /var/run/secrets/dockerhub/username)" \
        --password "$(cat /var/run/secrets/dockerhub/password)"
 
-# And push them.
+# Then tag and push them.
 for microservice in ${microservices}; do
-    docker push "${repo}/${microservice}" "${repo}/${microservice}:${DOCKER_TAG}"
+    docker tag "${repo}/${microservice}" "${repo}/${microservice}:${DOCKER_TAG}"
+    docker push "${repo}/${microservice}:${DOCKER_TAG}"
 done
 
 docker logout

--- a/k8s/build-tag-push
+++ b/k8s/build-tag-push
@@ -8,7 +8,8 @@ microservices="s4-common tahoe-introducer tahoe-storage foolscap-gatherer"
 ./leastauthority.com/docker/build.sh
 
 # Log in to Docker Hub so we can push the images.
-docker login \
+# https://github.com/moby/moby/issues/6400
+yes | docker login \
        --username "$(cat /var/run/secrets/dockerhub/username)" \
        --password "$(cat /var/run/secrets/dockerhub/password)"
 

--- a/k8s/build-tag-push
+++ b/k8s/build-tag-push
@@ -16,7 +16,7 @@ yes | docker login \
 
 # And push them.
 for microservice in ${microservices}; do
-    docker push "${repo}/${microservice}:${DOCKER_TAG}"
+    docker push "${repo}/${microservice}" "${repo}/${microservice}:${DOCKER_TAG}"
 done
 
 docker logout

--- a/k8s/build-tag-push
+++ b/k8s/build-tag-push
@@ -1,34 +1,20 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 # Copyright Least Authority Enterprises.
 # See LICENSE for details.
 
-SERVER_PORT=30000
-SERVER="127.0.0.1:${SERVER_PORT}"
-
-microservices="web grid-router tahoe-introducer tahoe-storage foolscap-gatherer subscription-manager subscription-converger"
+microservices="s4-common tahoe-introducer tahoe-storage foolscap-gatherer"
 
 # Build the images.
 ./leastauthority.com/docker/build.sh
 
-# Tag them in the way expected by the deployment configuration and
-# with the tag given in the environment.
-for microservice in ${microservices}; do
-    repo="leastauthority/${microservice}"
-    docker tag ${repo} "${SERVER}/${repo}:${DOCKER_TAG}"
-done
-
-# Forward a local port to the private registry so we can push the new images.
-twistd \
-    --pidfile /tmp/portforward.pid \
-    portforward \
-        --port 30000 \
-        --host private-registry.leastauthority-tweaks \
-        --dest_port ${SERVER_PORT}
+# Log in to Docker Hub so we can push the images.
+docker login "$(cat /var/run/secrets/dockerhub/username)" "$(cat /var/run/secrets/dockerhub/password)"
 
 # And push them.
 for microservice in ${microservices}; do
-    repo="leastauthority/${microservice}"
-    docker push "${SERVER}/${repo}:${DOCKER_TAG}"
+    docker push "${microservice}:${DOCKER_TAG}"
 done
+
+docker logout
 
 echo "Tagged images with ${DOCKER_TAG}"

--- a/k8s/build-tag-push
+++ b/k8s/build-tag-push
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 # Copyright Least Authority Enterprises.
 # See LICENSE for details.
 

--- a/k8s/dockerhub-secrets.yaml
+++ b/k8s/dockerhub-secrets.yaml
@@ -1,0 +1,46 @@
+apiVersion: ENC[AES256_GCM,data:kUc=,iv:IpW7uO8O4/UY+5TLvQl6FL4db5dRoCYhwbKWyULf2xw=,tag:XSghsNoGDhahgL2OrysbPQ==,type:str]
+kind: ENC[AES256_GCM,data:w6+W5fBs,iv:7U7r3l10phz5sX+9+IyduCgXRIPIJIgu17VXJ7DXwks=,tag:vjPVCWMQrWlG+oLRGSgJww==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:LnCI8NALzRxH,iv:70Az81g0B9DWp/ToI9tTmz/AwUqJiSKqXkkGoDMSveY=,tag:mm9dQGw+kj0YqqJLKSHOIg==,type:str]
+type: ENC[AES256_GCM,data:Eci/dPVX,iv:rx7i7MhQ4AsEUq9kEAgzn3MOEKr++x9VeKsvu3bEEfk=,tag:kLi0kPmTJWubKofZZsRFjw==,type:str]
+data:
+    username: ENC[AES256_GCM,data:EWl8Bkf0Q9n83Kcf,iv:kLkXgDJYgMsWVje2AlSrNAQBWByqCkp/44gI069tvRI=,tag:EPNbpR2iR7niU6wo3A/g3A==,type:str]
+    password: ENC[AES256_GCM,data:W6zdfbHawNoHx1CE4HntPAg44A185AZPtwFpe3O4qiOfkSgnzwW4EDzcDlMb5gV5,iv:hYszz7aJ0DYFxCMkZrHaU3cPpcPGaYMM9/A9OTXPPr0=,tag:YgALQOqMYDPz7Q1qxRm8fA==,type:str]
+sops:
+    mac: ENC[AES256_GCM,data:CYOwF9q7WZoEy0Xi618F+CqTD2khB6cveJYaFin1zeypObsbZnlBpriIdRZIO+5/5wBLvBJwZR7OdzeivvsBn+l5SeabYaWKmd3pyRhcvGRxPGASS2gqtcwgK9I998lcJJA8cDgXK4LFtV2+qD+wVM6+ZD+ilSIW3FZ3O0G1rRc=,iv:XgeC/pSVy40G9U6V/iK0WVrnPNZRMG7gaCgvC9RnK9g=,tag:b9+hlrC6MA20ByCqnWSDfA==,type:str]
+    version: '1.16'
+    pgp:
+    -   fp: 96B9C5DAB2EA9EB679419DB7E27B085EDEAA4B1B
+        created_at: '2017-07-12T13:37:19Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMAzNqg1saGXvSAQf/aog2Xvdxxgj5ljLb3d3w0xyfVcG+JwMxam7Yppe6+ccG
+            8mVTmdlPdTL/Ad7V3niHPs5DjMk2H2r9tKNawyGkC8H/2oR8Lka1ZK6dHDhueRFh
+            pnpuhOVofcjVNFhRl9iTNaE/aImO954N4g+md8pOmLmjRSZ9b5jFzjWUWKK8GD2x
+            XhDzjdlKvXcZ/mmT3wi5LdNYSGuB0GhUDQ3srNA0wU/WX8xP+n3+iT8xSLsWsd+0
+            fpHUyR/zqfBn6xcE5HiAgC9bLA+S0jWhxLZn0LrUsNnJVHaGGWyaUoAz2htuNXuJ
+            eqEnuL9FB66JpYAyHsrVQ2XZU00T1M7/0+ThAEGs0dJeAaXqHweWVDyJ4uGtkvXJ
+            4dhcSGmUcFJcqxSuO+EuO2eVjTtTP16efcQ2rgU+d4zLtAvQUbkcjaYiDDUvV+4K
+            rxAR7wy6BkkIDWGmlOAkhmzUvuOdubsGXtxTT9xFVQ==
+            =xX5B
+            -----END PGP MESSAGE-----
+    -   fp: 9D5A2BD5688ECB889DEBCD3FC2602803128069A7
+        created_at: '2017-07-12T13:37:19Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA5lOukqRk5SQAQf/bRCUoE/5OgYLrxU9wKssNmImuiAYQaCLQ/DtCjfUq3wa
+            TvynJIzV0WiQsMjD3Dqzpg680WBJ44+n3jCgqpmnA7gssLF5cxtGn/myiq2lqGTi
+            TYu3rx4SLKH4BuD0qjtE5ma0F1py6fiE6ulGOH4H1rd6RRW57i3hZmJLK/y+yg51
+            riQYtEX0De790FcWHjcz+6MZEcfYdUETjD2gYbZrAQzhnqp/QLJbtZ7G+nQl9ixZ
+            0MIerOpdDGC1N4zjvDOfaOfwQRBJxcVhBvslELFK+qJTPWuuRYwpKZQLMjzw1Rjc
+            XyyL7j3hniUazQxfCyQc4sDW7P+p8nc76fTdUuAzFNJeAdKManfU7ENeE+LurvOM
+            nANYYUSstRGMNnQJzG2LWL7RtPDrHKcN0kBRJjsGxgMHiI3BcGBxCupYVOCG8DoT
+            p39gop1GqDhUHua/dPRbUV2hRwYiZrIE9sLjiXZrMQ==
+            =somy
+            -----END PGP MESSAGE-----
+    lastmodified: '2017-07-12T13:42:27Z'
+    attention: This section contains key material that should only be modified with
+        extra care. See `sops -h`.
+    unencrypted_suffix: _unencrypted


### PR DESCRIPTION
Updates the tool for building our images on K8S itself.  Necessary as Docker Cloud is proving to be a very high-latency build platform.

This is a first step towards independence from Docker-hosted builds.  Next step will be a tiny server that can accept GitHub push notifications and kick off builds automatically.