### PR TITLE
Update links to latest Gridsync release, docs

### DIFF
--- a/src/lae_site/templates/gridsync_activation.html
+++ b/src/lae_site/templates/gridsync_activation.html
@@ -5,7 +5,7 @@
   <a href="https://github.com/gridsync/gridsync">Gridsync</a> &ndash;
   a new graphical user interface for Tahoe-LAFS for joining storage grids and creating magic-folders.
   When prompted, enter the following single-use invite code
-  <a href="https://github.com/warner/magic-wormhole">(?)</a>:
+  <a href="https://github.com/gridsync/gridsync/blob/master/docs/invite-codes.md">(?)</a>:
 </p>
 
 <!-- The wormhole code is the really important piece of information on this
@@ -18,22 +18,22 @@
 <p>
   <ul>
     <li>
-      <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Linux.tar.gz">Linux</a>
-      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Linux.tar.gz.asc">sig</a>]
-      <a href="https://en.wikipedia.org/wiki/Digital_signature">(?)</a>
+      <a href="https://github.com/gridsync/gridsync/releases/download/v0.1.0/Gridsync-Linux.tar.gz">Linux</a>
+      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.1.0/Gridsync-Linux.tar.gz.asc">sig</a>]
+      <a href="https://github.com/gridsync/gridsync/blob/master/docs/verifying-signatures.md">(?)</a>
     </li>
     <li>
-      <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Mac.dmg">Mac</a>
-      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Mac.dmg.asc">sig</a>]
-      <a href="https://en.wikipedia.org/wiki/Digital_signature">(?)</a>
+      <a href="https://github.com/gridsync/gridsync/releases/download/v0.1.0/Gridsync-Mac.dmg">Mac</a>
+      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.1.0/Gridsync-Mac.dmg.asc">sig</a>]
+      <a href="https://github.com/gridsync/gridsync/blob/master/docs/verifying-signatures.md">(?)</a>
     </li>
     <li>
-      <a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Windows.zip">Windows</a>
-      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.0.5/Gridsync-Windows.zip.asc">sig</a>]
-      <a href="https://en.wikipedia.org/wiki/Digital_signature">(?)</a>
+      <a href="https://github.com/gridsync/gridsync/releases/download/v0.1.0/Gridsync-Windows.zip">Windows</a>
+      [<a href="https://github.com/gridsync/gridsync/releases/download/v0.1.0/Gridsync-Windows.zip.asc">sig</a>]
+      <a href="https://github.com/gridsync/gridsync/blob/master/docs/verifying-signatures.md">(?)</a>
     </li>
     <li>
-      <a href="https://github.com/gridsync/gridsync/archive/v0.0.5.tar.gz">source code</a>
+      <a href="https://github.com/gridsync/gridsync/archive/v0.1.0.tar.gz">source code</a>
     </li>
   </ul>
 </p>


### PR DESCRIPTION
This PR updates the pre-existing download links for Gridsync binary packages and their accompanying signatures to the latest (0.1.0) release. In addition, it updates the "(?)" helper links, swapping the Wikipedia "digital signatures" article with the more guided [verifying signatures guide](https://github.com/gridsync/gridsync/blob/master/docs/verifying-signatures.md) (#577) and the bare link to the magic-wormhole GitHub repo with the [invite codes primer](https://github.com/gridsync/gridsync/blob/master/docs/invite-codes.md) (#579).

As [mentioned previously](https://github.com/LeastAuthority/leastauthority.com/pull/572#issuecomment-313796752), it would probably be a good idea to reproduce/mirror the content of these docs somewhere on leastauthority.com too, however.