### PR TITLE
Publish and graph some more metrics

### DIFF
--- a/docker/Dockerfile.tahoe-base
+++ b/docker/Dockerfile.tahoe-base
@@ -12,4 +12,4 @@ ENV TAHOE_LAFS_GIT_BRANCH="2237-cloud-backend-s4"
 RUN git clone --depth=1 --branch="${TAHOE_LAFS_GIT_BRANCH}" "${TAHOE_LAFS_GIT_REPO_URL}" /app/code
 RUN /app/env/bin/pip install --find-links=https://tahoe-lafs.org/deps -e /app/code[test]
 
-ADD lae_automation/configure-tahoe /app/configure-tahoe
+ADD src/lae_automation/configure-tahoe /app/configure-tahoe

--- a/k8s/infrastructure.yaml
+++ b/k8s/infrastructure.yaml
@@ -53,7 +53,7 @@ spec:
 kind: 'Service'
 apiVersion: 'v1'
 metadata:
-  name: 's4-metrics'
+  name: 's4-signup-metrics'
   labels:
     provider: 'LeastAuthority'
     app: 's4-signup'

--- a/k8s/infrastructure.yaml
+++ b/k8s/infrastructure.yaml
@@ -50,6 +50,27 @@ spec:
     targetPort: 8080
     protocol: 'TCP'
 ---
+kind: 'Service'
+apiVersion: 'v1'
+metadata:
+  name: 's4-metrics'
+  labels:
+    provider: 'LeastAuthority'
+    app: 's4-signup'
+    component: 'Infrastructure'
+spec:
+  selector:
+    provider: 'LeastAuthority'
+    app: 's4-signup'
+    component: 'Infrastructure'
+  type: 'ClusterIP'
+  ports:
+  # The signup server exposes Prometheus-compoatible metrics.
+  - name: 'metrics'
+    port: 9000
+    targetPort: 9000
+    protocol: 'TCP'
+---
 # Read about services at
 # http://kubernetes.io/docs/user-guide/services/
 kind: 'Service'
@@ -300,13 +321,15 @@ spec:
           - '--stripe-publishable-api-key-path=/app/k8s_secrets/stripe-publishable.key'
           - '--site-logs-path=/app/log/httpd.json'
           - '--subscription-manager=http://subscription-manager/'
+          - '--metrics-port=tcp:9000'
           - '--eliot-destination'
           - 'file:/app/log/twist.json'
         workingDir: '/app/run'
         ports:
-        # We just happen to know this is the ports this container listens on.
+        # We just happen to know these are the ports this container listens on.
         - containerPort: 8443
         - containerPort: 8080
+        - containerPort: 9000
         volumeMounts:
         # We just happen to know these are the paths the container
         # wants to use for interesting, persistent state.

--- a/k8s/infrastructure.yaml
+++ b/k8s/infrastructure.yaml
@@ -490,6 +490,7 @@ spec:
           - '--k8s-service-account'
           - '--kubernetes-namespace'
           - '$(POD_KUBERNETES_NAMESPACE)'
+          - '--metrics-port=tcp:9000'
           - '--eliot-destination'
           - 'file:/app/log/router.json'
         env:
@@ -497,6 +498,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: 'metadata.namespace'
+        ports:
+        - containerPort: 9000
         volumeMounts:
         - mountPath: '/app/log'
           name: 'logs'

--- a/k8s/infrastructure.yaml
+++ b/k8s/infrastructure.yaml
@@ -53,19 +53,18 @@ spec:
 kind: 'Service'
 apiVersion: 'v1'
 metadata:
-  name: 's4-signup-metrics'
+  name: 's4-metrics'
   labels:
     provider: 'LeastAuthority'
-    app: 's4-signup'
+    app: 's4'
     component: 'Infrastructure'
 spec:
   selector:
     provider: 'LeastAuthority'
-    app: 's4-signup'
     component: 'Infrastructure'
   type: 'ClusterIP'
   ports:
-  # The signup server exposes Prometheus-compoatible metrics.
+  # All S4 metrics-exposing services will do it like this.
   - name: 'metrics'
     port: 9000
     targetPort: 9000

--- a/k8s/infrastructure/fluentd.yaml
+++ b/k8s/infrastructure/fluentd.yaml
@@ -63,10 +63,6 @@ data:
       </store>
       <store>
         @type relabel
-        @label @METRICS_SIGNUP
-      </store>
-      <store>
-        @type relabel
         @label @METRICS_ERRORS
       </store>
       <store>
@@ -152,34 +148,6 @@ data:
           desc Total S4 Unhandled Errors
         </metric>
       </filter>
-    </label>
-
-    <label @METRICS_SIGNUP>
-      # Scrape S4 signup metrics out of the log stream and expose it to
-      # Prometheus.
-      <filter signup>
-        @type where
-
-        # Match only wormhole-signup success events.
-        where action_type = 'wormhole-signup' AND action_status = 'succeeded'
-      </filter>
-
-      # Take the output of the signup filter and turn it into a Prometheus
-      # metric.
-      <filter signup>
-        @type prometheus
-        <metric>
-          name s4_signup_counter
-          type counter
-          desc Total S4 Signups
-        </metric>
-      </filter>
-
-      <match signup>
-        # Quiet the logs by defining an output for this tag.  Without this, we
-        # get warnings like `no patterns matched tag="..."`.
-        @type null
-      </match>
     </label>
 
     <label @METRICS_DEPLOYMENTS>

--- a/k8s/monitoring/grafana-dashboards.py
+++ b/k8s/monitoring/grafana-dashboards.py
@@ -23,13 +23,15 @@ from txkube import network_kubernetes_from_context
 
 
 def dashboard():
+    PROMETHEUS = "prometheus"
+
     return G.Dashboard(
         title="S4",
         rows=[
             G.Row(panels=[
                 G.Graph(
                     title="Signups",
-                    dataSource="prometheus",
+                    dataSource=PROMETHEUS,
                     xAxis=G.XAxis(
                         name="Total",
                         mode="time",

--- a/k8s/monitoring/grafana-dashboards.py
+++ b/k8s/monitoring/grafana-dashboards.py
@@ -39,11 +39,11 @@ def dashboard():
                     yAxes=[
                         G.YAxis(
                             format="none",
-                            label="#",
+                            label="Count",
                         ),
                         G.YAxis(
                             format="none",
-                            label="#",
+                            label="Count",
                         ),
                     ],
                     targets=[

--- a/k8s/monitoring/grafana-dashboards.py
+++ b/k8s/monitoring/grafana-dashboards.py
@@ -72,6 +72,7 @@ def dashboard():
                     targets=[
                         G.Target(
                             expr='s4_deployment_gauge',
+                            refId="D",
                         ),
                     ],
                 ),
@@ -83,6 +84,7 @@ def dashboard():
                     targets=[
                         G.Target(
                             expr='s4_unhandled_error_counter',
+                            refId="E",
                         ),
                     ],
                 ),

--- a/k8s/monitoring/grafana-dashboards.py
+++ b/k8s/monitoring/grafana-dashboards.py
@@ -48,17 +48,17 @@ def dashboard():
                     ],
                     targets=[
                         G.Target(
-                            expr="wormhole_signup_started",
+                            expr='wormhole_signup_started{pod=~"s4-signup.*"}',
                             legendFormat="Wormhole Signups Started",
                             refId="A",
                         ),
                         G.Target(
-                            expr="wormhole_signup_success",
+                            expr='wormhole_signup_success{pod=~"s4-signup.*"}',
                             legendFormat="Wormhole Signups Completed",
                             refId="B",
                         ),
                         G.Target(
-                            expr="wormhole_signup_failure",
+                            expr='wormhole_signup_failure{pod=~"s4-signup.*"}',
                             legendFormat="Wormhole Signups Failed",
                             refId="C",
                         ),

--- a/k8s/monitoring/grafana-dashboards.py
+++ b/k8s/monitoring/grafana-dashboards.py
@@ -27,6 +27,43 @@ def dashboard():
         title="S4",
         rows=[
             G.Row(panels=[
+                G.Graph(
+                    title="Signups",
+                    dataSource="prometheus",
+                    xAxis=G.XAxis(
+                        name="Total",
+                        mode="time",
+                    ),
+                    yAxes=[
+                        G.YAxis(
+                            format="none",
+                            label="#",
+                        ),
+                        G.YAxis(
+                            format="none",
+                            label="#",
+                        ),
+                    ],
+                    targets=[
+                        G.Target(
+                            expr="wormhole_signup_started",
+                            legendFormat="Wormhole Signups Started",
+                            refId="A",
+                        ),
+                        G.Target(
+                            expr="wormhole_signup_success",
+                            legendFormat="Wormhole Signups Completed",
+                            refId="B",
+                        ),
+                        G.Target(
+                            expr="wormhole_signup_failure",
+                            legendFormat="Wormhole Signups Failed",
+                            refId="C",
+                        ),
+                    ],
+                ),
+            ]),
+            G.Row(panels=[
                 G.SingleStat(
                     title='Current Customer Deployments',
                     dataSource='prometheus',
@@ -35,17 +72,6 @@ def dashboard():
                     targets=[
                         G.Target(
                             expr='s4_deployment_gauge',
-                        ),
-                    ],
-                ),
-                G.SingleStat(
-                    title='Signups',
-                    dataSource='prometheus',
-                    valueName='current',
-                    sparkline=G.SparkLine(show=True),
-                    targets=[
-                        G.Target(
-                            expr='s4_signup_counter',
                         ),
                     ],
                 ),

--- a/k8s/monitoring/grafana-dashboards.py
+++ b/k8s/monitoring/grafana-dashboards.py
@@ -66,6 +66,42 @@ def dashboard():
                 ),
             ]),
             G.Row(panels=[
+                G.Graph(
+                    title="Usage",
+                    dataSource=PROMETHEUS,
+
+                    # Stack the connection graphs on each other, revealing
+                    # both a total and a distribution across different grid
+                    # router instances.
+                    stack=True,
+                    tooltip=G.Tooltip(
+                        valueType=G.INDIVIDUAL,
+                    ),
+
+                    xAxis=G.XAxis(
+                        name="When",
+                        mode="time",
+                    ),
+                    yAxes=[
+                        G.YAxis(
+                            format="none",
+                            label="Count",
+                        ),
+                        G.YAxis(
+                            format="none",
+                            label="Count",
+                        ),
+                    ],
+                    targets=[
+                        G.Target(
+                            expr="grid_router_connections",
+                            legendFormat="Tahoe-LAFS Connections",
+                            refId="D",
+                        ),
+                    ],
+                ),
+            ]),
+            G.Row(panels=[
                 G.SingleStat(
                     title='Current Customer Deployments',
                     dataSource='prometheus',
@@ -74,7 +110,7 @@ def dashboard():
                     targets=[
                         G.Target(
                             expr='s4_deployment_gauge',
-                            refId="D",
+                            refId="E",
                         ),
                     ],
                 ),
@@ -86,7 +122,7 @@ def dashboard():
                     targets=[
                         G.Target(
                             expr='s4_unhandled_error_counter',
-                            refId="E",
+                            refId="F",
                         ),
                     ],
                 ),

--- a/k8s/monitoring/grafana-dashboards.py
+++ b/k8s/monitoring/grafana-dashboards.py
@@ -33,7 +33,7 @@ def dashboard():
                     title="Signups",
                     dataSource=PROMETHEUS,
                     xAxis=G.XAxis(
-                        name="Total",
+                        name="When",
                         mode="time",
                     ),
                     yAxes=[

--- a/k8s/monitoring/prometheus-servicemonitor.yaml
+++ b/k8s/monitoring/prometheus-servicemonitor.yaml
@@ -1,23 +1,49 @@
 # https://coreos.com/operators/prometheus/docs/latest/user-guides/getting-started.html
 #
-# The idea of our Prometheus architecture is that applications will log to
-# Fluentd and Fluentd will be configured with a Prometheus output plugin.  It
-# will construct the desired metrics data from the log stream and expose that
-# data to Prometheus for collection.
+# The _old_ idea of our Prometheus architecture is that applications will log
+# to Fluentd and Fluentd will be configured with a Prometheus output plugin.
+# It will construct the desired metrics data from the log stream and expose
+# that data to Prometheus for collection.
+#
+# The new idea is that, because Fluentd configuration is so clunky and
+# prometheus-operator is so good at going out and grabbing metrics from
+# different pods, we'll have a bunch of service monitors that tell prometheus
+# where to go look and let it do that and we'll shrink down Fluentd's role as
+# much as possible.
 
 apiVersion: 'monitoring.coreos.com/v1alpha1'
 kind: 'ServiceMonitor'
 metadata:
-  name: 's4'
+  name: 's4-fluentd'
   labels:
     provider: 'LeastAuthority'
     component: 'Monitoring'
 spec:
   selector:
     # Select the Fluentd server.
+
     matchLabels:
       provider: 'LeastAuthority'
       component: 'Monitoring'
   endpoints:
   # And scrape metrics from its prometheus output plugin.
   - port: 'prometheus'
+
+---
+apiVersion: 'monitoring.coreos.com/v1alpha1'
+kind: 'ServiceMonitor'
+metadata:
+  name: 's4-signup'
+  labels:
+    provider: 'LeastAuthority'
+    component: 'Monitoring'
+spec:
+  selector:
+    # Select the s4 signup server service.
+    matchLabels:
+      provider: 'LeastAuthority'
+      app: 's4-signup'
+      component: 'Infrastructure'
+  endpoints:
+  # And scrape metrics from its prometheus output plugin.
+  - port: 'metrics'

--- a/k8s/monitoring/prometheus.yaml
+++ b/k8s/monitoring/prometheus.yaml
@@ -12,3 +12,11 @@ spec:
   resources:
     requests:
       memory: '400Mi'
+
+  # Associate some persistent storage so that stats survive restarts,
+  # rescheduling, etc.
+  storage:
+    class: 'normal'
+    resources:
+      requests:
+        storage: '40Gi'

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ Nevow==0.14.2
 oauth2client==4.1.2
 oauthlib==2.0.2
 pem==16.1.0
+prometheus_client==0.0.19
 pyasn1==0.2.3
 pyasn1-modules==0.0.9
 pycparser==2.18

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "eliot",
 
         "txAWS",
+        "prometheus_client",
 
         "magic-wormhole",
 

--- a/src/lae_site/main.py
+++ b/src/lae_site/main.py
@@ -20,13 +20,10 @@ from twisted.application.service import MultiService
 from twisted.internet.defer import Deferred
 from twisted.python.usage import UsageError, Options
 from twisted.python.filepath import FilePath
-from twisted.web.resource import Resource
-from twisted.web.server import Site
-
-from prometheus_client.twisted import MetricsResource
 
 from wormhole import wormhole
 
+from lae_util import prometheus_exporter
 from lae_util.fluentd_destination import (
     opt_eliot_destination,
     eliot_logging_service,
@@ -201,12 +198,7 @@ def main(reactor, *argv):
 
 
 def start_metrics_site(reactor, port_string):
-    root = Resource()
-    root.putChild(b"metrics", MetricsResource())
-    service = StreamServerEndpointService(
-        serverFromString(reactor, port_string),
-        Site(root),
-    )
+    service = prometheus_exporter(reactor, port_string)
     service.privilegedStartService()
     service.startService()
 

--- a/src/lae_util/__init__.py
+++ b/src/lae_util/__init__.py
@@ -27,6 +27,8 @@ from ._retry import (
     decorate_methods,
 )
 
+from ._prometheus import prometheus_exporter
+
 def patch():
     from .twisted_8860 import detect, patch
     detect() and patch()

--- a/src/lae_util/_prometheus.py
+++ b/src/lae_util/_prometheus.py
@@ -1,0 +1,23 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
+from twisted.internet.endpoints import serverFromString
+from twisted.application.internet import StreamServerEndpointService
+from twisted.web.resource import Resource
+from twisted.web.server import Site
+
+from prometheus_client.twisted import MetricsResource
+
+
+def prometheus_exporter(reactor, port_string):
+    """
+    Create an ``IService`` that exposes Prometheus metrics from this process
+    on an HTTP server on the given port.
+    """
+    root = Resource()
+    root.putChild(b"metrics", MetricsResource())
+    service = StreamServerEndpointService(
+        serverFromString(reactor, port_string),
+        Site(root),
+    )
+    return service


### PR DESCRIPTION
This adds some more native metric collection/reporting and some Grafana configuration to visualize the information.

It also gives Prometheus a persistent storage volume so we actually keep our stats across pod restarts.