### PR TITLE
Update to tahoe-lafs with leasedb fixes

### DIFF
--- a/docker/Dockerfile.tahoe-base
+++ b/docker/Dockerfile.tahoe-base
@@ -7,9 +7,12 @@
 FROM leastauthority/base
 
 ENV TAHOE_LAFS_GIT_REPO_URL="https://github.com/leastauthority/tahoe-lafs.git"
-ENV TAHOE_LAFS_GIT_BRANCH="2237-cloud-backend-s4"
+ENV TAHOE_LAFS_GIT_REV="5fcb270878a0ca9db95ca54b4203c6fc6e7f633c"
 
-RUN git clone --depth=1 --branch="${TAHOE_LAFS_GIT_BRANCH}" "${TAHOE_LAFS_GIT_REPO_URL}" /app/code
+RUN git clone "${TAHOE_LAFS_GIT_REPO_URL}" /app/code && \
+    git -C /app/code checkout "${TAHOE_LAFS_GIT_REV}"
+
+
 RUN /app/env/bin/pip install --find-links=https://tahoe-lafs.org/deps -e /app/code[test]
 
 ADD src/lae_automation/configure-tahoe /app/configure-tahoe


### PR DESCRIPTION
Fixes #594 
Fixes #595 

These errors have to do with recovery from loss of the leasedb in the Tahoe-LAFS cloud backend branch.  This change updates our Dockerfile so it will build Tahoe-LAFS images that use the revision of Tahoe-LAFS which includes the two leasedb fixes that eliminate these errors.

Additional changes (not included here) are required to update our deployments to use these new images.