### PR TITLE
Add requires.io badge for security notifications

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,10 @@ leastauthority.com
 .. image:: https://travis-ci.org/LeastAuthority/leastauthority.com.svg?master
     :target: https://travis-ci.org/LeastAuthority/leastauthority.com
 
+.. image:: https://requires.io/github/LeastAuthority/leastauthority.com/requirements.svg?branch=requires-io-master
+     :target: https://requires.io/github/LeastAuthority/leastauthority.com/requirements/?branch=requires-io-master
+     :alt: Requirements Status
+
 This website is a Twisted Web server with a set of static files.
 It also has some application logic for using Kubernetes (k8s) and Amazon Web Services (aws) on behalf of LAE customers.
 

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ leastauthority.com
 .. image:: https://travis-ci.org/LeastAuthority/leastauthority.com.svg?master
     :target: https://travis-ci.org/LeastAuthority/leastauthority.com
 
-.. image:: https://requires.io/github/LeastAuthority/leastauthority.com/requirements.svg?branch=requires-io-master
-     :target: https://requires.io/github/LeastAuthority/leastauthority.com/requirements/?branch=requires-io-master
+.. image:: https://requires.io/github/LeastAuthority/leastauthority.com/requirements.svg?branch=master
+     :target: https://requires.io/github/LeastAuthority/leastauthority.com/requirements/?branch=master
      :alt: Requirements Status
 
 This website is a Twisted Web server with a set of static files.


### PR DESCRIPTION
Fixes #466 

Doesn't _actually_ fix the issue described by #466 but it does create a notification that something needs attention.  Separately, configuration on requires.io will cause a PR to be generated any time an insecure Python dependency is noticed.