### PR TITLE
Update to tahoe-lafs with prefix/marker fix

### DIFF
--- a/docker/Dockerfile.tahoe-base
+++ b/docker/Dockerfile.tahoe-base
@@ -7,7 +7,7 @@
 FROM leastauthority/base
 
 ENV TAHOE_LAFS_GIT_REPO_URL="https://github.com/leastauthority/tahoe-lafs.git"
-ENV TAHOE_LAFS_GIT_REV="d2ba7235163c5e16b9fa5a1d3351a3d34252d6bc"
+ENV TAHOE_LAFS_GIT_REV="e77aa51be"
 
 RUN git clone "${TAHOE_LAFS_GIT_REPO_URL}" /app/code && \
     git -C /app/code checkout "${TAHOE_LAFS_GIT_REV}"

--- a/docker/Dockerfile.tahoe-base
+++ b/docker/Dockerfile.tahoe-base
@@ -7,7 +7,7 @@
 FROM leastauthority/base
 
 ENV TAHOE_LAFS_GIT_REPO_URL="https://github.com/leastauthority/tahoe-lafs.git"
-ENV TAHOE_LAFS_GIT_REV="e77aa51be"
+ENV TAHOE_LAFS_GIT_REV="d82ae8cc9"
 
 RUN git clone "${TAHOE_LAFS_GIT_REPO_URL}" /app/code && \
     git -C /app/code checkout "${TAHOE_LAFS_GIT_REV}"


### PR DESCRIPTION
tahoe-lafs d2ba7235163c5e16b9fa5a1d3351a3d34252d6bc introduced a bug in the handling of shares with large numbers of chunks (>1000).  Bump our version to one which includes a fix for this bug.