### PR TITLE
Update some dependencies on security concerns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ chardet==3.0.4
 chargebee==2.4.3
 click==6.7
 constantly==15.1.0
-cryptography==2.0.3
+cryptography==2.3.1
 eliot==1.1.0
 enum34==1.1.6
 filepath==0.1
@@ -35,11 +35,10 @@ prometheus-client==0.0.20
 pyasn1==0.3.4
 pyasn1-modules==0.1.4
 pycparser==2.18
-pycrypto==2.6.1
 pycryptopp==0.7.1.869544967005693312591928092448767568728501330214
 pykube==0.15.0
 PyNaCl==1.1.2
-pyOpenSSL==17.2.0
+pyOpenSSL==18.0.0
 pyrsistent==0.13.0
 python-dateutil==2.6.1
 pytz==2017.2
@@ -54,7 +53,7 @@ simplejson==3.11.1
 six==1.10.0
 spake2==0.7
 stripe==1.65.0
-tahoe-lafs==1.12.1
+tahoe-lafs==1.13.0
 tqdm==4.15.0
 treq==17.8.0
 Twisted==17.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ treq==17.8.0
 Twisted==17.5.0
 txaio==2.8.2
 txAWS==0.4.0
-txkube==0.2.0
+txkube==0.3.0
 txtorcon==0.19.3
 tzlocal==1.4
 urllib3==1.22

--- a/test-tools/tahoe-test.sh
+++ b/test-tools/tahoe-test.sh
@@ -3,7 +3,7 @@
 TAHOE_ENV=$1
 shift
 
-WORMHOLE_CODE=$1
+INTRODUCER=$1
 shift
 
 PROBE_FILE=$(mktemp /tmp/probe-XXXXXXXXXXXX)
@@ -15,15 +15,16 @@ TAHOE="${TAHOE_ENV}/bin/tahoe"
 CFG="${TAHOE_NODE}/tahoe.cfg"
 
 if [ ! -e "${TAHOE}" ]; then
-    virtualenv "${TAHOE_ENV}"
+    virtualenv --python=python2 "${TAHOE_ENV}"
     "${TAHOE_ENV}"/bin/pip install tahoe-lafs
 fi
 
 "${TAHOE}" \
-    --wormhole-server "ws://wormhole.staging.leastauthority.com:4000/v1" \
-    --wormhole-invite-appid "tahoe-lafs.org/invite" \
     create-client \
-    --join "${WORMHOLE_CODE}" \
+    --introducer "${INTRODUCER}" \
+    --shares-needed=1 \
+    --shares-happy=1 \
+    --shares-total=1 \
     "${TAHOE_NODE}"
 sed --regexp-extended --in-place=.bak -e 's/web.port = tcp:3456:/web.port = tcp:0:/' "${CFG}"
 "${TAHOE}" start "${TAHOE_NODE}"


### PR DESCRIPTION
By upgrading Tahoe-LAFS, we can drop the pycrypto dependency entirely.
The pyOpenSSL and pycryptography upgrades get us fixes for a few
CVEs (that probably don't much affect us but this doesn't hurt at all).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/leastauthority.com/754)
<!-- Reviewable:end -->
