### PR TITLE
Authorize convergence

### DIFF
--- a/k8s/infrastructure.yaml
+++ b/k8s/infrastructure.yaml
@@ -425,6 +425,61 @@ spec:
             cpu: '100m'
             memory: '200Mi'
 ---
+# Read about ServiceAccounts at
+# https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+#
+# This account is for the subscription convergence pod which needs to query,
+# create, and destroy a number of different resource types to achieve
+# convergence.
+kind: 'ServiceAccount'
+apiVersion: 'v1'
+metadata:
+  name: 'subscription-converger'
+---
+# Read about ClusterRoles at
+# https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole
+#
+# This ClusterRole grants necessary authorizations to the ServiceAccount for
+# the subscription convergence agent.
+kind: 'ClusterRole'
+apiVersion: 'rbac.authorization.k8s.io/v1'
+metadata:
+  name: 'subscription-converger'
+rules:
+- apiGroups:
+    # magical empty string represents the core api group.
+    # pods, services, configmaps are in the core api group.
+    - ""
+    # for deployments
+    - "extensions"
+    # for replicasets
+    - "apps"
+  resources:
+    - "services"
+    - "configmaps"
+    - "deployments"
+    - "replicasets"
+    - "pods"
+  verbs:
+    - "list"
+    - "get"
+    - "create"
+    - "delete"
+---
+# Read about ClusterRoleBindings at
+# https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding
+kind: 'ClusterRoleBinding'
+apiVersion: 'rbac.authorization.k8s.io/v1'
+metadata:
+  name: 'read-convergeable-cluster-state'
+subjects:
+- kind: 'User'
+  name: 'system:serviceaccount:default:subscription-converger'
+roleRef:
+  kind: 'ClusterRole'
+  name: 'subscription-converger'
+  apiGroup: 'rbac.authorization.k8s.io'
+---
 # Read about deployments at
 # http://kubernetes.io/docs/user-guide/deployments/
 kind: 'Deployment'
@@ -453,6 +508,10 @@ spec:
         component: 'Infrastructure'
         version: '2'
     spec:
+      # Get a service account with the necessary authorization to make the
+      # Kubernetes queries we require (configmaps, deployments, etc) for
+      # convergence.
+      serviceAccountName: 'subscription-converger'
       volumes:
       - name: 'convergence-secrets'
         secret:

--- a/ops/deploy-master
+++ b/ops/deploy-master
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-PRODUCTION="useast1.production1-11.leastauthority.com"
+CONTEXT="$1"
 
 HEAD="$(git rev-parse HEAD)"
 master="$(git rev-parse master)"
@@ -12,7 +12,7 @@ fi
 
 git fetch origin master
 
-APPLY="kubectl --context ${PRODUCTION} apply"
+APPLY="kubectl --context ${CONTEXT} apply"
 REWRITE="python k8s/rewrite-objects.py --git-tag HEAD"
 
 ./k8s/build
@@ -33,7 +33,7 @@ cat k8s/monitoring/tahoe-lafs-transfer-rate.yaml | \
     ${REWRITE} | \
     ${APPLY} -f -
 
-python k8s/monitoring/grafana-dashboards.py ${PRODUCTION} | \
+python k8s/monitoring/grafana-dashboards.py ${CONTEXT} | \
     ${APPLY} -f -
 
 cat k8s/monitoring/grafana.yaml | \

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ tqdm==4.15.0
 treq==17.8.0
 Twisted==17.5.0
 txaio==2.8.2
-txAWS==0.4.0
+-e git://github.com/twisted/txaws.git@5c3317376cd47e536625027e38c3b37840175ce0#egg=txAWS
 -e git://github.com/LeastAuthority/txkube.git@a7e555d#egg=txkube
 txtorcon==0.19.3
 tzlocal==1.4

--- a/src/lae_automation/subscription_converger.py
+++ b/src/lae_automation/subscription_converger.py
@@ -763,7 +763,7 @@ def _converge_route53_customer(actual, config, subscriptions, k8s, aws):
 
     Message.log(
         event=u"convergence-service:route53-customer",
-        create=list(subscription.id for subscription in changes.create),
+        create=list(subscription.subscription_id for subscription in changes.create),
         delete=changes.delete,
     )
     return deletes + creates

--- a/src/lae_automation/subscription_converger.py
+++ b/src/lae_automation/subscription_converger.py
@@ -764,7 +764,7 @@ def _converge_route53_customer(actual, config, subscriptions, k8s, aws):
     Message.log(
         event=u"convergence-service:route53-customer",
         create=list(subscription.subscription_id for subscription in changes.create),
-        delete=changes.delete,
+        delete=list(changes.delete),
     )
     return deletes + creates
 

--- a/src/lae_automation/subscription_converger.py
+++ b/src/lae_automation/subscription_converger.py
@@ -760,6 +760,12 @@ def _converge_route53_customer(actual, config, subscriptions, k8s, aws):
         return create_route53_rrsets(route53, actual.zone.zone, [subscription])
     deletes = list(partial(delete, sid) for sid in changes.delete)
     creates = list(partial(create, s) for s in changes.create)
+
+    Message.log(
+        event=u"convergence-service:route53-customer",
+        create=list(subscription.id for subscription in changes.create),
+        delete=changes.delete,
+    )
     return deletes + creates
 
 


### PR DESCRIPTION
Explicitly grant the convergence agent the necessary Kubernetes permissions using the RBAC system.  This was previously not necessary but newer versions of Kubernetes require it.

A few other useful changes go along with this.  These were suggested in the course of testing out the RBAC changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/leastauthority.com/766)
<!-- Reviewable:end -->
