### PR TITLE
Perform necessary Route53 paging

### DIFF
--- a/src/grid_router/test/test_router.py
+++ b/src/grid_router/test/test_router.py
@@ -71,9 +71,7 @@ class GridRouterStateMachine(RuleBasedStateMachine):
         self.clock = Clock()
         self.reactor = FakeReactor(self.network, self.clock)
         self.kubernetes = memory_kubernetes()
-        self.client = self.case.successResultOf(
-            self.kubernetes.versioned_client()
-        )
+        self.client = self.kubernetes.client()
         self.model = self.client.model
 
         self.deploy_config = NullDeploymentConfiguration()

--- a/src/lae_automation/containers.py
+++ b/src/lae_automation/containers.py
@@ -90,12 +90,6 @@ def create_configuration(deploy_config, details, model):
     public_host = configmap_public_host(details.subscription_id, deploy_config.domain)
     private_host = deploy_config.private_host
 
-    Message.log(
-        event=u"convergence-service:key-notification",
-        key_id=deploy_config.s3_access_key_id,
-        secret_key_hash=sha256(deploy_config.s3_secret_key).hexdigest().decode("ascii"),
-    )
-
     configuration = marshal_tahoe_configuration(
         introducer_pem=details.introducer_node_pem,
         storage_pem=details.server_node_pem,

--- a/src/lae_automation/subscription_converger.py
+++ b/src/lae_automation/subscription_converger.py
@@ -679,6 +679,11 @@ class _ChangeableConfigMaps(PClass):
 
 
 def _converge_configmaps(actual, deploy_config, subscriptions, k8s, aws):
+    Message.log(
+        event=u"convergence-service:configmaps:key-notification",
+        key_id=deploy_config.s3_access_key_id,
+        secret_key_hash=sha256(deploy_config.s3_secret_key).hexdigest().decode("ascii"),
+    )
     changes = _compute_changes(
         actual.subscriptions,
         _ChangeableConfigMaps(

--- a/src/lae_automation/subscription_converger.py
+++ b/src/lae_automation/subscription_converger.py
@@ -945,13 +945,13 @@ def _load_all_rrsets(route53, zone_identifier, name=None, type=None, accum=None)
             # Make sure we also preserve the Eliot context for callbacks of
             # this next Deferred.
             with start_action(action_type="load-next-page").context():
-                d = _load_all_rrsets(
+                d = DeferredContext(_load_all_rrsets(
                     route53,
                     zone_identifier,
                     name=maxkey.label,
                     type=maxkey.type,
                     accum=accum,
-                )
+                ))
                 return d.addActionFinish()
         d.addCallback(got_some_rrsets)
         return d.addActionFinish()

--- a/src/lae_automation/subscription_converger.py
+++ b/src/lae_automation/subscription_converger.py
@@ -944,15 +944,15 @@ def _load_all_rrsets(route53, zone_identifier, name=None, type=None, accum=None)
             maxkey = max(rrsets)
             # Make sure we also preserve the Eliot context for callbacks of
             # this next Deferred.
-            return DeferredContext(
-                _load_all_rrsets(
+            with start_action(action_type="load-next-page").context():
+                d = _load_all_rrsets(
                     route53,
                     zone_identifier,
                     name=maxkey.label,
                     type=maxkey.type,
                     accum=accum,
-                ),
-            )
+                )
+                return d.addActionFinish()
         d.addCallback(got_some_rrsets)
         return d.addActionFinish()
 

--- a/src/lae_automation/subscription_converger.py
+++ b/src/lae_automation/subscription_converger.py
@@ -894,7 +894,7 @@ def get_hosted_zone_by_name(route53, name):
             for zone in zones:
                 # XXX Bleuch zone.name should be a Name!
                 if Name(zone.name) == name:
-                    d = route53.list_resource_record_sets(zone_id=zone.identifier)
+                    d = _load_all_rrsets(route53, zone.identifier)
                     d.addCallback(
                         lambda rrsets, zone=zone: _ZoneState(
                             zone=zone,
@@ -905,6 +905,48 @@ def get_hosted_zone_by_name(route53, name):
             raise KeyError(name)
         d.addCallback(filter_results)
         return d.addActionFinish()
+
+
+
+def _load_all_rrsets(route53, zone_identifier, name=None, type=None, accum=None):
+    """
+    Load all rrsets for a given zone, collecting multiple pages of results if
+    necessary.
+    """
+    if accum is None:
+        accum = {}
+    d = route53.list_resource_record_sets(
+        zone_id=zone_identifier,
+        # Make sure we know how many results to expect.  This is the default
+        # and maximum allowed item limit, though.
+        maxitems=100,
+        # Start the page at the rrset identified by these two values.
+        name=name,
+        type=type,
+    )
+    def got_some_rrsets(rrsets):
+        accum.update(rrsets)
+        if len(rrsets) < 100:
+            # Fewer results than we asked for means we must be on the last
+            # page.
+            return accum
+
+        # Otherwise, ask for the next page.  We do this slightly wrong, using
+        # max(rrsets) as the starting key because txaws does not give us
+        # access to the correct values from the response -
+        # NextRecordIdentifier and NextRecordType.  This just means we'll load
+        # one duplicate item on each page.  They all go into the dict so it
+        # doesn't affect correctness.
+        maxkey = max(rrsets)
+        return _load_all_rrsets(
+            route53,
+            zone_identifier,
+            name=maxkey.label,
+            type=maxkey.type,
+            accum=accum,
+        )
+    d.addCallback(got_some_rrsets)
+    return d
 
 
 

--- a/src/lae_automation/test/test_subscription_converger.py
+++ b/src/lae_automation/test/test_subscription_converger.py
@@ -786,7 +786,7 @@ class ConvergenceLoopMetricsTests(TestCase):
         service.startService()
         reactor.advance(interval)
         last_completed = next(iter(list(
-            metric.samples[-1][-1]
+            metric.samples[-1].value
             for metric
             in REGISTRY.collect()
             if metric.name == u"s4_last_convergence_succeeded"


### PR DESCRIPTION
If there are more than 100 RRSets in the managed zone, everything beyond the first 100 is missed by the current zone loading code.  This adds the necessary logic to page through the results, ensuring we consider them all.  This prevents us from spuriously attempting to re-create (on every pass through the convergence loop) RRSets we believe are missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/leastauthority.com/768)
<!-- Reviewable:end -->
