### PR TITLE
Add paging to the route53 input loader

### DIFF
--- a/src/lae_automation/subscription_converger.py
+++ b/src/lae_automation/subscription_converger.py
@@ -894,7 +894,7 @@ def get_hosted_zone_by_name(route53, name):
             for zone in zones:
                 # XXX Bleuch zone.name should be a Name!
                 if Name(zone.name) == name:
-                    d = route53.list_resource_record_sets(zone_id=zone.identifier)
+                    d = _load_all_rrsets(route53, zone.identifier)
                     d.addCallback(
                         lambda rrsets, zone=zone: _ZoneState(
                             zone=zone,
@@ -904,6 +904,56 @@ def get_hosted_zone_by_name(route53, name):
                     return d
             raise KeyError(name)
         d.addCallback(filter_results)
+        return d.addActionFinish()
+
+
+
+def _load_all_rrsets(route53, zone_identifier, name=None, type=None, accum=None):
+    """
+    Load all rrsets for a given zone, collecting multiple pages of results if
+    necessary.
+    """
+    a = start_action(event=u"load-all-rrsets")
+    with a.context():
+        if accum is None:
+            accum = {}
+        d = DeferredContext(
+            route53.list_resource_record_sets(
+                zone_id=zone_identifier,
+                # Make sure we know how many results to expect.  This is the
+                # default and maximum allowed item limit, though.
+                maxitems=100,
+                # Start the page at the rrset identified by these two values.
+                name=name,
+                type=type,
+            ),
+        )
+        def got_some_rrsets(rrsets):
+            accum.update(rrsets)
+            if len(rrsets) < 100:
+                # Fewer results than we asked for means we must be on the last
+                # page.
+                return accum
+
+            # Otherwise, ask for the next page.  We do this slightly wrong, using
+            # max(rrsets) as the starting key because txaws does not give us
+            # access to the correct values from the response -
+            # NextRecordIdentifier and NextRecordType.  This just means we'll load
+            # one duplicate item on each page.  They all go into the dict so it
+            # doesn't affect correctness.
+            maxkey = max(rrsets)
+            # Make sure we also preserve the Eliot context for callbacks of
+            # this next Deferred.
+            with start_action(action_type="load-next-page").context():
+                d = DeferredContext(_load_all_rrsets(
+                    route53,
+                    zone_identifier,
+                    name=maxkey.label,
+                    type=maxkey.type,
+                    accum=accum,
+                ))
+                return d.addActionFinish()
+        d.addCallback(got_some_rrsets)
         return d.addActionFinish()
 
 


### PR DESCRIPTION
If there are more than 100 RRSets in the managed zone, everything beyond the first 100 is missed by the current zone loading code. This adds the necessary logic to page through the results, ensuring we consider them all. This prevents us from spuriously attempting to re-create (on every pass through the convergence loop) RRSets we believe are missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/leastauthority.com/769)
<!-- Reviewable:end -->
