### PR TITLE
Pin Python 2.7 in the travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
     # This builder will run our test suite directly.
     - env: ENV="testing"
       language: "python"
+      python: "2.7"
       # Cache ~/.cache/pip
       # https://docs.travis-ci.com/user/caching/#pip-cache
       cache: "pip"

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -15,3 +15,4 @@ traceback2==1.4.0
 unittest2==1.1.0
 txkube[dev]==0.2.0
 eliot-tree==17.1.0
+pytest==4.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 --find-links https://tahoe-lafs.org/deps/
 asn1crypto==0.22.0
-attrs==17.2.0
+attrs==17.4.0
 autobahn==17.9.2
 Automat==0.6.0
 certifi==2017.7.27.1


### PR DESCRIPTION
> This job ran using the default Python version, which was updated to 3.6 on
> April 16th, 2019. You can explicitly stay on the previous version by
> specifying python: 2.7 in your .travis.yml.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/leastauthority.com/779)
<!-- Reviewable:end -->
